### PR TITLE
add tests forceExit, forceTransfer, transfer & exit with amount = 0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -414,9 +414,9 @@
       }
     },
     "@hermeznetwork/commonjs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@hermeznetwork/commonjs/-/commonjs-0.3.0.tgz",
-      "integrity": "sha512-3PVd1hNC29NG/+qBj2Ls+O5tdtYDwpnio/g+vsVel/RI3Zr4+q+OCdjdAsGPNpBBoNcf6j71tPb/k+M2TPifQA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@hermeznetwork/commonjs/-/commonjs-0.3.2.tgz",
+      "integrity": "sha512-LjgT3x7OSOBaiLRe5W6Le3aTejkdzU8eW67CbbRYUQeb3IN1QaGcW/59jZ5WtIh9kmcBYrLnWLXwkvrrRY+OCw==",
       "requires": {
         "chai": "^4.2.0",
         "circomlib": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "HermezDAO",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@hermeznetwork/commonjs": "^0.3.0",
+    "@hermeznetwork/commonjs": "^0.3.2",
     "circom": "^0.5.35",
     "circom_runtime": "^0.1.9",
     "circomlib": "^0.5.0",

--- a/src/rollup-main.circom
+++ b/src/rollup-main.circom
@@ -66,7 +66,7 @@ include "./fee-tx.circom";
  * @input ay2[nTx] - {Array(Field)} - ay of the receiver leaf
  * @input ethAddr2[nTx] - {Array(Uint160)} - ethAddr of the receiver leaf
  * @input siblings2[nTx][nLevels + 1] - {Array[Array(Field)]} - siblings merkle proof of the receiver leaf
- * @input newExit[nTx] - {Array(Bool)} - determines if the transaction createsq a new account in the exit tree
+ * @input newExit[nTx] - {Array(Bool)} - determines if the transaction creates a new account in the exit tree
  * @input isOld0_2[nTx] - {Array(Bool)} - flag to require old key - value
  * @input oldKey2[nTx] - {Array(Uint48)} - old key of the sender leaf
  * @input oldValue2[nTx] - {Array(Field)} - old value of the sender leaf

--- a/src/rollup-main.circom
+++ b/src/rollup-main.circom
@@ -66,6 +66,7 @@ include "./fee-tx.circom";
  * @input ay2[nTx] - {Array(Field)} - ay of the receiver leaf
  * @input ethAddr2[nTx] - {Array(Uint160)} - ethAddr of the receiver leaf
  * @input siblings2[nTx][nLevels + 1] - {Array[Array(Field)]} - siblings merkle proof of the receiver leaf
+ * @input newExit[nTx] - {Array(Bool)} - determines if the transaction createsq a new account in the exit tree
  * @input isOld0_2[nTx] - {Array(Bool)} - flag to require old key - value
  * @input oldKey2[nTx] - {Array(Uint48)} - old key of the sender leaf
  * @input oldValue2[nTx] - {Array(Field)} - old value of the sender leaf

--- a/src/rollup-tx.circom
+++ b/src/rollup-tx.circom
@@ -61,6 +61,7 @@ include "./lib/decode-float.circom"
  * @input nonce2 - {Uint40} - nonce of the receiver leaf
  * @input sign2 - {Bool} - sign of the receiver leaf
  * @input balance2 - {Uint192} - balance of the receiver leaf
+ * @input newExit - {Array(Bool)} - determines if the transaction creates a new account in the exit tree
  * @input ay2 - {Field} - ay of the receiver leaf
  * @input ethAddr2 - {Uint160} - ethAddr of the receiver leaf
  * @input siblings2[nLevels + 1] - {Array(Field)} - siblings merkle proof of the receiver leaf
@@ -494,6 +495,7 @@ template RollupTx(nLevels, maxFeeTx) {
     balanceUpdater.nullifyAmount <== states.nullifyAmount;
 
     isAmountNullified <== balanceUpdater.isAmountNullified;
+
     // H - accumulate fees
     ////////
     component feeAccumulator = FeeAccumulator(maxFeeTx);

--- a/test/rollup-main-L1.test.js
+++ b/test/rollup-main-L1.test.js
@@ -53,7 +53,7 @@ describe("Test rollup-main L1 transactions", function () {
         console.log("Constraints: " + circuit.constraints.length + "\n");
 
         // const testerAux = require("circom").testerAux;
-        // const pathTmp = "/tmp/circom_30968hGUXakefukFo";
+        // const pathTmp = "/tmp/circom_21395lnVeHFrhxFAm";
         // circuit = await testerAux(pathTmp, path.join(__dirname, "circuits", "rollup-main-L1.test.circom"));
     });
 
@@ -215,9 +215,6 @@ describe("Test rollup-main L1 transactions", function () {
         await bb.build();
         await assertBatch(bb, circuit);
     });
-
-    // NOTE: It is assumed that edge cases for amountF and loadAmountF are considered tested for
-    // all transactions types
 
     it("Should process L1 'deposit' txs edge cases", async () => {
         const rollupDB = await newState();
@@ -397,6 +394,26 @@ describe("Test rollup-main L1 transactions", function () {
         bb.addTx(tx3);
         await bb.build();
         await assertBatch(bb, circuit);
+
+        // transfer 0 amount
+        bb = await rollupDB.buildBatch(nTx, nLevels, maxL1Tx, maxFeeTx);
+        const tx4 = Object.assign({}, tx);
+        tx4.amount = 0;
+
+        bb.addTx(tx4);
+        await bb.build();
+        await assertBatch(bb, circuit);
+
+        // 2 transfers: amount != 0 & amount = 0
+        bb = await rollupDB.buildBatch(nTx, nLevels, maxL1Tx, maxFeeTx);
+        const tx5 = Object.assign({}, tx);
+        const tx6 = Object.assign({}, tx);
+        tx6.amount = 0;
+
+        bb.addTx(tx5);
+        bb.addTx(tx6);
+        await bb.build();
+        await assertBatch(bb, circuit);
     });
 
     it("Should process L1 'forceExit' txs edge cases", async () => {
@@ -443,6 +460,28 @@ describe("Test rollup-main L1 transactions", function () {
         tx3.fromEthAddr = account2.ethAddr;
 
         bb.addTx(tx3);
+        await bb.build();
+        await assertBatch(bb, circuit);
+
+        // force exit with amount = 0
+        // should not create a new leaf in the exit tree
+        bb = await rollupDB.buildBatch(nTx, nLevels, maxL1Tx, maxFeeTx);
+        const tx4 = Object.assign({}, tx);
+        tx4.amount = 0;
+
+        bb.addTx(tx4);
+        await bb.build();
+        await assertBatch(bb, circuit);
+
+        // 2 force exits: amount != 0 & amount = 0
+        // should not create a new leaf in the exit tree
+        bb = await rollupDB.buildBatch(nTx, nLevels, maxL1Tx, maxFeeTx);
+        const tx5 = Object.assign({}, tx);
+        const tx6 = Object.assign({}, tx);
+        tx6.amount = 0;
+
+        bb.addTx(tx5);
+        bb.addTx(tx6);
         await bb.build();
         await assertBatch(bb, circuit);
     });


### PR DESCRIPTION
This PR does the following:
- updates npm package `@hermeznetwork/commonjs` to version `0.3.2`
  - check fixes [here](https://github.com/hermeznetwork/commonjs/pull/20)
- add test for the following cases:
  - L1 forceExit with amount = 0
  - Two L1 forceExits: amount != 0 & amount = 0
  - L1 force Transfer with amount = 0
  - Two L1 forceTransfers: amount != 0 & amount = 0
  - L2 exit with amount = 0
  - Two L2 exits: amount != 0 & amount = 0
  - L2 transfer with amount = 0
  - Two L2 transfers: amount != 0 & amount = 0   