### PR TITLE
remove exit-tree, add exitBalance and accHash in state

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "setup": "npm i",
     "eslint": "npx eslint test/** tools/*.js tools/helpers/*.js",
-    "test": "npx mocha --max-old-space-size=4096 ./test/*.test.js && npx mocha ./test/lib/*.test.js"
+    "test": "npx mocha --max-old-space-size=4096 ./test/*.test.js && npx mocha ./test/lib/*.test.js",
+    "extend-circom": "node ./tools/reuse-compiled-circuits/reuse-circuits.js"
   },
   "keywords": [
     "hermez",

--- a/src/fee-tx.circom
+++ b/src/fee-tx.circom
@@ -20,6 +20,8 @@ include "./lib/hash-state.circom";
  * @input balance - {Uint192} - balance of leaf feeIdx
  * @input ay - {Field} - ay of leaf feeIdx
  * @input ethAddr - {Uint160} - ethAddr of leaf feeIdx
+ * @input exitBalance - {Uint192} - account exit balance
+ * @input accumulatedHash - {Field} - received transactions hash chain
  * @input siblings[nLevels + 1]- {Array[Field]} - siblings merkle proof
  * @output newStateRoot - {Field} - new state root
  */
@@ -37,6 +39,8 @@ template FeeTx(nLevels){
     signal input balance;
     signal input ay;
     signal input ethAddr;
+    signal input exitBalance;
+    signal input accumulatedHash;
     signal input siblings[nLevels+1];
 
     signal output newStateRoot;
@@ -81,6 +85,8 @@ template FeeTx(nLevels){
     oldStFeePck.balance <== balance;
     oldStFeePck.ay <== ay;
     oldStFeePck.ethAddr <== ethAddr;
+    oldStFeePck.exitBalance <== exitBalance;
+    oldStFeePck.accumulatedHash <== accumulatedHash;
 
     // new state packer
     ////////
@@ -91,6 +97,8 @@ template FeeTx(nLevels){
     newStFeePck.balance <== accFee + balance; // old balance + fee accumulated
     newStFeePck.ay <== ay;
     newStFeePck.ethAddr <== ethAddr;
+    newStFeePck.exitBalance <== exitBalance;
+    newStFeePck.accumulatedHash <== accumulatedHash;
 
     // smt processor
     ////////

--- a/src/rollup-tx.circom
+++ b/src/rollup-tx.circom
@@ -298,7 +298,7 @@ template RollupTx(nLevels, maxFeeTx) {
 
     // E - signal processor selectors
     ////////
-    // decode BjjCompumulatedressed
+    // decode BjjCompressed
     component decodeFromBjj = BitsCompressed2AySign();
     for (i = 0; i < 256; i++){
         decodeFromBjj.bjjCompressed[i] <== fromBjjCompressed[i];

--- a/src/rollup-tx.circom
+++ b/src/rollup-tx.circom
@@ -40,6 +40,7 @@ include "./lib/decode-float.circom"
  * @input rqTxCompressedDataV2 - {Uint193} - requested encode transaction fields together version 2
  * @input rqToEthAddr - {Uint160} - requested ethereum address receiver
  * @input rqToBjjAy - {Field} - requested babyjubjub y coordinate
+ * @input L1L2TxDataNum - {Field} - L1-L2 data availability integer
  * @input sigL2Hash - {Field} - hash L2 data to sign
  * @input s - {Field} - eddsa signature field
  * @input r8x - {Field} - eddsa signature field
@@ -53,6 +54,8 @@ include "./lib/decode-float.circom"
  * @input balance1 - {Uint192} - balance of the sender leaf
  * @input ay1 - {Field} - ay of the sender leaf
  * @input ethAddr1 - {Uint160} - ethAddr of the sender leaf
+ * @input exitBalance1 - {Uint192} - account exit balance
+ * @input accumulatedHash1 - {Field} - received transactions hash chain
  * @input siblings1[nLevels + 1] - {Array(Field)} - siblings merkle proof of the sender leaf
  * @input isOld0_1 - {Bool} - flag to require old key - value
  * @input oldKey1 - {Uint48} - old key of the sender leaf
@@ -61,19 +64,14 @@ include "./lib/decode-float.circom"
  * @input nonce2 - {Uint40} - nonce of the receiver leaf
  * @input sign2 - {Bool} - sign of the receiver leaf
  * @input balance2 - {Uint192} - balance of the receiver leaf
- * @input newExit - {Array(Bool)} - determines if the transaction creates a new account in the exit tree
  * @input ay2 - {Field} - ay of the receiver leaf
  * @input ethAddr2 - {Uint160} - ethAddr of the receiver leaf
+ * @input exitBalance2 - {Uint192} - account exit balance
+ * @input accumulatedHash2 - {Field} - received transactions hash chain
  * @input siblings2[nLevels + 1] - {Array(Field)} - siblings merkle proof of the receiver leaf
- * @input isOld0_2 - {Bool} - flag to require old key - value
- * @input oldKey2 - {Uint48} - old key of the receiver leaf
- * @input oldValue2 - {Field} - old value of the receiver leaf
  * @input oldStateRoot - {Field} - initial state root
- * @input oldExitRoot - {Field} - initial exit root
- * @output isAmountNullified - {Bool} - determines if the amount is nullified
  * @output accFeeOut[maxFeeTx] - {Array(Uint192)} - final fees accumulated
  * @output newStateRoot - {Field} - final state root
- * @output newExitRoot - {Field} - final exit root
  */
 template RollupTx(nLevels, maxFeeTx) {
     // Phases rollup-tx circuit
@@ -87,7 +85,6 @@ template RollupTx(nLevels, maxFeeTx) {
         // H: accumulate fess
         // I: compute hash new states
         // J: smt processors
-        // K: select output roots
 
     // Accumulate fees
     signal input feePlanTokens[maxFeeTx];
@@ -126,6 +123,7 @@ template RollupTx(nLevels, maxFeeTx) {
     signal input rqToEthAddr;
     signal input rqToBjjAy;
 
+    signal input L1L2TxDataNum;
     signal input sigL2Hash;
     signal input s;
     signal input r8x;
@@ -143,6 +141,8 @@ template RollupTx(nLevels, maxFeeTx) {
     signal input balance1;
     signal input ay1;
     signal input ethAddr1;
+    signal input exitBalance1;
+    signal input accumulatedHash1;
     signal input siblings1[nLevels+1];
     // Required for inserts and delete
     signal input isOld0_1;
@@ -154,41 +154,23 @@ template RollupTx(nLevels, maxFeeTx) {
     signal input nonce2;
     signal input sign2;
     signal input balance2;
-    signal input newExit;
     signal input ay2;
     signal input ethAddr2;
+    signal input exitBalance2;
+    signal input accumulatedHash2;
     signal input siblings2[nLevels+1];
-    // Required for inserts and delete
-    signal input isOld0_2;
-    signal input oldKey2;
-    signal input oldValue2;
 
     // Roots
     signal input oldStateRoot;
     signal output newStateRoot;
-
-    signal input oldExitRoot;
-    signal output newExitRoot;
-
-    // Nullifier amount
-    signal output isAmountNullified;
 
     var i;
 
     // A - compute tx-states
     ////////
     // decode loadAmountF
-    signal loadAmount;
-
-    component n2bloadAmountF = Num2Bits(40);
-    n2bloadAmountF.in <== loadAmountF;
-
-    component dfLoadAmount = DecodeFloatBin();
-    for (i = 0; i < 40; i++) {
-        dfLoadAmount.in[i] <== n2bloadAmountF.out[i];
-    }
-
-    dfLoadAmount.out ==> loadAmount;
+    component decodeLoadAmountF = DecodeFloat();
+    decodeLoadAmountF.in <== loadAmountF;
 
     // compute states
     component states = RollupTxStates();
@@ -198,8 +180,7 @@ template RollupTx(nLevels, maxFeeTx) {
     states.auxFromIdx <== auxFromIdx;
     states.auxToIdx <== auxToIdx;
     states.amount <== amount;
-    states.newExit <== newExit;
-    states.loadAmount <== loadAmount;
+    states.loadAmount <== decodeLoadAmountF.out;
     states.newAccount <== newAccount;
     states.onChain <== onChain;
     states.fromEthAddr <== fromEthAddr;
@@ -273,7 +254,7 @@ template RollupTx(nLevels, maxFeeTx) {
     component checkTokenID2 = ForceEqualIfEnabled();
     checkTokenID2.in[0] <== tokenID;
     checkTokenID2.in[1] <== tokenID2;
-    checkTokenID2.enabled <== (1 - onChain)*(1 - states.isP2Insert);
+    checkTokenID2.enabled <== (1 - onChain);
 
     // force sender tokenID on L1-create-account
     // if tx type involves an account creation, it is forced that the account created
@@ -301,6 +282,8 @@ template RollupTx(nLevels, maxFeeTx) {
     oldSt1Hash.balance <== balance1;
     oldSt1Hash.ay <== ay1;
     oldSt1Hash.ethAddr <== ethAddr1;
+    oldSt1Hash.exitBalance <== exitBalance1;
+    oldSt1Hash.accumulatedHash <== accumulatedHash1;
 
     // oldState2 Packer
     component oldSt2Hash = HashState();
@@ -310,10 +293,12 @@ template RollupTx(nLevels, maxFeeTx) {
     oldSt2Hash.balance <== balance2;
     oldSt2Hash.ay <== ay2;
     oldSt2Hash.ethAddr <== ethAddr2;
+    oldSt2Hash.exitBalance <== exitBalance2;
+    oldSt2Hash.accumulatedHash <== accumulatedHash2;
 
     // E - signal processor selectors
     ////////
-    // decode BjjCompressed
+    // decode BjjCompumulatedressed
     component decodeFromBjj = BitsCompressed2AySign();
     for (i = 0; i < 256; i++){
         decodeFromBjj.bjjCompressed[i] <== fromBjjCompressed[i];
@@ -365,6 +350,20 @@ template RollupTx(nLevels, maxFeeTx) {
     s1TokenID.c[1] <== tokenID;
     s1TokenID.s <== states.isP1Insert;
 
+    // INSERT: sender exit balance would be 0
+    // otherwise, exit balance sender account will be selected
+    component s1ExitBalance = Mux1();
+    s1ExitBalance.c[0] <== exitBalance1;
+    s1ExitBalance.c[1] <== 0;
+    s1ExitBalance.s <== states.isP1Insert;
+
+    // INSERT: sender accumulated hash would be 0
+    // otherwise, accumulated hash sender account will be selected
+    component s1AccumulatedHash = Mux1();
+    s1AccumulatedHash.c[0] <== accumulatedHash1;
+    s1AccumulatedHash.c[1] <== 0;
+    s1AccumulatedHash.s <== states.isP1Insert;
+
     // INSERT: processor old key would be taken from 'oldKey1' which is set by the coordinator
     // otherwise, key is selected from states depending on tx type
     component s1OldKey = Mux1();
@@ -378,69 +377,6 @@ template RollupTx(nLevels, maxFeeTx) {
     s1OldValue.c[0] <== oldSt1Hash.out;
     s1OldValue.c[1] <== oldValue1;
     s1OldValue.s <== states.isP1Insert;
-
-    // state processor 2 : isExit * newExit
-    // perform INSERT if transaction is an 'exit' and involves and account creation on exit tree
-    // Note: when exit tx is performed and it involves an account creation on the exoit tree, the account created
-    // on the exit tree would be equal as the sender account
-    // the following multiplexers choose between signals if state processor is an INSERT
-
-    // INSERT: new exit account balance would be 0
-    // otherwise, balance receiver account will be selected
-    component s2Balance = Mux1();
-    s2Balance.c[0] <== balance2;
-    s2Balance.c[1] <== 0;
-    s2Balance.s <== states.isP2Insert;
-
-    // INSERT: babyjubjub sign will be taken from sender leaf
-    // otherwise, babyjubjub sign receiver account would be selected
-    component s2Sign = Mux1();
-    s2Sign.c[0] <== sign2;
-    s2Sign.c[1] <== s1Sign.out;
-    s2Sign.s <== states.isP2Insert;
-
-    // INSERT: babyjubjub Y coordinate will be taken from sender leaf
-    // otherwise, babyjubjub sign receiver account would be selected
-    component s2Ay = Mux1();
-    s2Ay.c[0] <== ay2;
-    s2Ay.c[1] <== s1Ay.out;
-    s2Ay.s <== states.isP2Insert;
-
-    // INSERT: nonce will be 0
-    // otherwise, nonce receiver account would be selected
-    // Note: exit tree leafs has always nonce 0
-    component s2Nonce = Mux1();
-    s2Nonce.c[0] <== nonce2;
-    s2Nonce.c[1] <== 0;
-    s2Nonce.s <== states.isP2Insert;
-
-    // INSERT: ethereum address will be taken from sender leaf
-    // otherwise, ethereum address receiver account would be selected
-    component s2EthAddr = Mux1();
-    s2EthAddr.c[0] <== ethAddr2;
-    s2EthAddr.c[1] <== s1EthAddr.out;
-    s2EthAddr.s <== states.isP2Insert;
-
-    // INSERT: token identifier will be taken from sender leaf
-    // otherwise, token identifier receiver account would be selected
-    component s2TokenID = Mux1();
-    s2TokenID.c[0] <== tokenID2;
-    s2TokenID.c[1] <== s1TokenID.out;
-    s2TokenID.s <== states.isP2Insert;
-
-    // INSERT: procesor old key will be taken from 'oldKey2' which is set by the coordinator
-    // otherwise, key is selected from states depending on tx type
-    component s2OldKey = Mux1();
-    s2OldKey.c[0] <== states.key2;
-    s2OldKey.c[1] <== oldKey2;
-    s2OldKey.s <== states.isP2Insert;
-
-    // INSERT: processor state hash would be taken from 'oldValue1' which is set by the coordinator
-    // otherwise, state hash is selected from states depending on tx type
-    component s2OldValue = Mux1();
-    s2OldValue.c[0] <== oldSt2Hash.out;
-    s2OldValue.c[1] <== oldValue2;
-    s2OldValue.s <== states.isP2Insert;
 
     // F - verify eddsa signature
     ////////
@@ -484,17 +420,27 @@ template RollupTx(nLevels, maxFeeTx) {
     // G - update balances
     ////////
     component balanceUpdater = BalanceUpdater();
-    balanceUpdater.oldStBalanceSender <== s1Balance.out;
-    balanceUpdater.oldStBalanceReceiver <== s2Balance.out;
+    balanceUpdater.oldBalanceSender <== s1Balance.out;
+    balanceUpdater.oldBalanceReceiver <== balance2;
+    balanceUpdater.oldExitBalanceReceiver <== exitBalance2;
     balanceUpdater.amount <== amount;
-    balanceUpdater.loadAmount <== loadAmount;
+    balanceUpdater.loadAmount <== decodeLoadAmountF.out;
     balanceUpdater.feeSelector <== userFee;
     balanceUpdater.onChain <== onChain;
     balanceUpdater.nop <== states.nop;
+    balanceUpdater.isExit <== states.isExit;
     balanceUpdater.nullifyLoadAmount <== states.nullifyLoadAmount;
     balanceUpdater.nullifyAmount <== states.nullifyAmount;
 
-    isAmountNullified <== balanceUpdater.isAmountNullified;
+    // update accumulatedHash
+    component computeAccumulatedHash = Poseidon(2);
+    computeAccumulatedHash.inputs[0] <== accumulatedHash2;
+    computeAccumulatedHash.inputs[1] <== L1L2TxDataNum;
+
+    component s2AccumulatedHash = Mux1();
+    s2AccumulatedHash.c[0] <== accumulatedHash2;
+    s2AccumulatedHash.c[1] <== computeAccumulatedHash.out;
+    s2AccumulatedHash.s <== (1 - balanceUpdater.isAmountNullified) * (1 - states.isExit);
 
     // H - accumulate fees
     ////////
@@ -518,18 +464,22 @@ template RollupTx(nLevels, maxFeeTx) {
     newSt1Hash.tokenID <== s1TokenID.out;
     newSt1Hash.nonce <== s1Nonce.out + (1 - onChain);
     newSt1Hash.sign <== s1Sign.out;
-    newSt1Hash.balance <== balanceUpdater.newStBalanceSender;
+    newSt1Hash.balance <== balanceUpdater.newBalanceSender;
     newSt1Hash.ay <== s1Ay.out;
     newSt1Hash.ethAddr <== s1EthAddr.out;
+    newSt1Hash.exitBalance <== s1ExitBalance.out;
+    newSt1Hash.accumulatedHash <== s1AccumulatedHash.out;
 
     // newState2 hash state
     component newSt2Hash = HashState();
-    newSt2Hash.tokenID <== s2TokenID.out;
-    newSt2Hash.nonce <== s2Nonce.out;
-    newSt2Hash.sign <== s2Sign.out;
-    newSt2Hash.balance <== balanceUpdater.newStBalanceReceiver;
-    newSt2Hash.ay <== s2Ay.out;
-    newSt2Hash.ethAddr <== s2EthAddr.out;
+    newSt2Hash.tokenID <== tokenID2;
+    newSt2Hash.nonce <== nonce2;
+    newSt2Hash.sign <== sign2;
+    newSt2Hash.balance <== balanceUpdater.newBalanceReceiver;
+    newSt2Hash.ay <== ay2;
+    newSt2Hash.ethAddr <== ethAddr2;
+    newSt2Hash.exitBalance <== balanceUpdater.newExitBalanceReceiver;
+    newSt2Hash.accumulatedHash <== s2AccumulatedHash.out;
 
     // J - smt processors
     ////////
@@ -547,45 +497,19 @@ template RollupTx(nLevels, maxFeeTx) {
     processor1.fnc[0] <== states.P1_fnc0;
     processor1.fnc[1] <== states.P1_fnc1;
 
-    // select processor 2 root input
-    // depending on tx type. IF tx is an 'Exit' select 'oldExitRoot', otherwise
-    // select output root of processor 1 (state root)
-    component s3 = Mux1();
-    s3.c[0] <== processor1.newRoot;
-    s3.c[1] <== oldExitRoot;
-    s3.s <== states.isExit;
-
     // processor 2: receiver
     component processor2 = SMTProcessor(nLevels+1) ;
-    processor2.oldRoot <== s3.out;
+    processor2.oldRoot <== processor1.newRoot;
     for (i = 0; i < nLevels + 1; i++) {
         processor2.siblings[i] <== siblings2[i];
     }
-    processor2.oldKey <== s2OldKey.out;
-    processor2.oldValue <== s2OldValue.out;
-    processor2.isOld0 <== isOld0_2;
+    processor2.oldKey <== states.key2;
+    processor2.oldValue <== oldSt2Hash.out;
+    processor2.isOld0 <== 0;
     processor2.newKey <== states.key2;
     processor2.newValue <== newSt2Hash.out;
-    processor2.fnc[0] <== states.P2_fnc0*balanceUpdater.isP2Nop;
-    processor2.fnc[1] <== states.P2_fnc1*balanceUpdater.isP2Nop;
+    processor2.fnc[0] <== states.P2_fnc0;
+    processor2.fnc[1] <== states.P2_fnc1;
 
-    // K - select output roots
-    ////////
-    // new state root
-    // if tx is an 'exit', select output root of processor 1 (sender)
-    // otherwise, select output root of processor 2 (receiver)
-    component s4 = Mux1();
-    s4.c[0] <== processor2.newRoot;
-    s4.c[1] <== processor1.newRoot;
-    s4.s <== states.isExit;
-    s4.out ==> newStateRoot;
-
-    // new exit root
-    // if tx is an 'exit', select output root of processor 2 (receiver)
-    // otherwise, select 'oldExitRoot' since exit root will not be updated
-    component s5 = Mux1();
-    s5.c[0] <== oldExitRoot;
-    s5.c[1] <== processor2.newRoot;
-    s5.s <== states.isExit;
-    s5.out ==> newExitRoot;
+    processor2.newRoot ==> newStateRoot;
 }

--- a/test/decode-tx.test.js
+++ b/test/decode-tx.test.js
@@ -268,7 +268,7 @@ describe("Test Decode Tx", function () {
         await circuit.assertOut(w, checkOut);
     });
 
-    it("Should check L1L2TxData", async () => {
+    it("Should check L1L2TxData & L1L2TxDataNum", async () => {
 
         const indexBits = (NLEVELS/8) * 8;
         const amountBits = 40;
@@ -315,12 +315,13 @@ describe("Test Decode Tx", function () {
         let tmp = txUtils.encodeL2Tx(tx, NLEVELS);
         let res = Scalar.fromString(tmp, 16);
         let resBits = Scalar.bits(res).reverse();
-        while(resBits.length < totalBits){
+        while (resBits.length < totalBits){
             resBits.unshift(0);
         }
 
         let checkOut = {
             L1L2TxData: resBits,
+            L1L2TxDataNum: res
         };
 
         await circuit.assertOut(w, checkOut);
@@ -336,12 +337,13 @@ describe("Test Decode Tx", function () {
         tmp = txUtils.encodeL2Tx(tx, NLEVELS);
         res = Scalar.fromString(tmp, 16);
         resBits = Scalar.bits(res).reverse();
-        while(resBits.length < totalBits){
+        while (resBits.length < totalBits){
             resBits.unshift(0);
         }
 
         checkOut = {
             L1L2TxData: resBits,
+            L1L2TxDataNum: res
         };
 
         await circuit.assertOut(w, checkOut);
@@ -355,12 +357,13 @@ describe("Test Decode Tx", function () {
         const tmpL1 = txUtils.encodeL1Tx(tx, NLEVELS);
         const resL1 = Scalar.fromString(tmpL1, 16);
         let resL1Bits = Scalar.bits(resL1).reverse();
-        while(resL1Bits.length < totalBits){
+        while (resL1Bits.length < totalBits){
             resL1Bits.unshift(0);
         }
 
         checkOut = {
             L1L2TxData: resL1Bits,
+            L1L2TxDataNum: resL1
         };
 
         await circuit.assertOut(w, checkOut);

--- a/test/fee-tx.test.js
+++ b/test/fee-tx.test.js
@@ -11,30 +11,37 @@ const { depositTx, random } = require("./helpers/helpers");
 
 describe("Test fee-tx", function () {
     this.timeout(0);
+
+    const reuse = false;
+    const pathTmp = "/tmp/circom_28537fw4bNa2wkhW";
+
     let circuitPath = path.join(__dirname, "fee-tx.test.circom");
     let circuit;
 
     let nLevels = 16;
 
     before( async() => {
-        const circuitCode = `
-            include "../src/fee-tx.circom";
-            component main = FeeTx(${nLevels});
-        `;
+        if (!reuse){
+            const circuitCode = `
+                include "../src/fee-tx.circom";
+                component main = FeeTx(${nLevels});
+            `;
 
-        fs.writeFileSync(circuitPath, circuitCode, "utf8");
+            fs.writeFileSync(circuitPath, circuitCode, "utf8");
 
-        circuit = await tester(circuitPath, {reduceConstraints:false});
-        await circuit.loadConstraints();
-        console.log("Constraints: " + circuit.constraints.length + "\n");
+            circuit = await tester(circuitPath, {reduceConstraints:false});
+            await circuit.loadConstraints();
+            console.log("Constraints: " + circuit.constraints.length + "\n");
+        } else {
+            const testerAux = require("circom").testerAux;
+            circuit = await testerAux(pathTmp, path.join(__dirname, "circuits", "fee-tx.test.circom"));
+        }
 
-        // const testerAux = require("circom").testerAux;
-        // const pathTmp = "/tmp/circom_30214TGGN7Rai1jx8";
-        // circuit = await testerAux(pathTmp, path.join(__dirname, "circuits", "fee-tx.test.circom"));
     });
 
     after( async() => {
-        fs.unlinkSync(circuitPath);
+        if (!reuse)
+            fs.unlinkSync(circuitPath);
     });
 
     it("Should check empty fee-tx", async () => {
@@ -49,6 +56,8 @@ describe("Test fee-tx", function () {
             balance: 0,
             ay: 0,
             ethAddr: 0,
+            exitBalance: 0,
+            accumulatedHash: 0,
             siblings: Array(nLevels+1).fill(0),
         };
 
@@ -68,6 +77,8 @@ describe("Test fee-tx", function () {
             balance: random(2**128),
             ay: random(2**253),
             ethAddr: random(2**160),
+            exitBalance: random(2**192),
+            accumulatedHash: Scalar.e(random(2**253)),
             siblings: Array(nLevels+1).fill(0),
         };
 
@@ -153,6 +164,8 @@ describe("Test fee-tx", function () {
             balance: genInput.balance3[0],
             ay: genInput.ay3[0],
             ethAddr: genInput.ethAddr3[0],
+            exitBalance: genInput.exitBalance3[0],
+            accumulatedHash: genInput.accumulatedHash3[0],
             siblings: genInput.siblings3[0],
         };
 
@@ -171,6 +184,8 @@ describe("Test fee-tx", function () {
             balance: genInput.balance3[1],
             ay: genInput.ay3[1],
             ethAddr: genInput.ethAddr3[1],
+            exitBalance: genInput.exitBalance3[1],
+            accumulatedHash: genInput.accumulatedHash3[1],
             siblings: genInput.siblings3[1],
         };
 
@@ -190,6 +205,8 @@ describe("Test fee-tx", function () {
             balance: random(2**128),
             ay: random(2**253),
             ethAddr: random(2**160),
+            exitBalance: random(2**192),
+            accumulatedHash: Scalar.e(random(2**253)),
             siblings: Array(nLevels+1).fill(0),
         };
 

--- a/test/rollup-main-L1.test.js
+++ b/test/rollup-main-L1.test.js
@@ -13,6 +13,10 @@ const { depositTx, assertBatch } = require("./helpers/helpers");
 
 describe("Test rollup-main L1 transactions", function () {
     this.timeout(0);
+
+    const reuse = false;
+    const pathTmp = "/tmp/circom_30032vVekuTkAbazR";
+
     let circuitPath = path.join(__dirname, "rollup-main-L1.test.circom");
     let circuit;
 
@@ -41,24 +45,26 @@ describe("Test rollup-main L1 transactions", function () {
     }
 
     before( async() => {
-        const circuitCode = `
-            include "../src/rollup-main.circom";
-            component main = RollupMain(${nTx}, ${nLevels}, ${maxL1Tx}, ${maxFeeTx});
-        `;
+        if (!reuse){
+            const circuitCode = `
+                include "../src/rollup-main.circom";
+                component main = RollupMain(${nTx}, ${nLevels}, ${maxL1Tx}, ${maxFeeTx});
+            `;
 
-        fs.writeFileSync(circuitPath, circuitCode, "utf8");
+            fs.writeFileSync(circuitPath, circuitCode, "utf8");
 
-        circuit = await tester(circuitPath, {reduceConstraints:false});
-        await circuit.loadConstraints();
-        console.log("Constraints: " + circuit.constraints.length + "\n");
-
-        // const testerAux = require("circom").testerAux;
-        // const pathTmp = "/tmp/circom_21395lnVeHFrhxFAm";
-        // circuit = await testerAux(pathTmp, path.join(__dirname, "circuits", "rollup-main-L1.test.circom"));
+            circuit = await tester(circuitPath, {reduceConstraints:false});
+            await circuit.loadConstraints();
+            console.log("Constraints: " + circuit.constraints.length + "\n");
+        } else {
+            const testerAux = require("circom").testerAux;
+            circuit = await testerAux(pathTmp, path.join(__dirname, "circuits", "rollup-main-L1.test.circom"));
+        }
     });
 
     after( async() => {
-        fs.unlinkSync(circuitPath);
+        if (!reuse)
+            fs.unlinkSync(circuitPath);
     });
 
     // table parameters L1 transactions

--- a/test/rollup-tx.test.js
+++ b/test/rollup-tx.test.js
@@ -14,6 +14,10 @@ const { depositTx, getSingleTxInput, assertTxs } = require("./helpers/helpers");
 
 describe("Test rollup-tx", function () {
     this.timeout(0);
+
+    const reuse = false;
+    const pathTmp = "/tmp/circom_28537fw4bNa2wkhW";
+
     let circuitPath = path.join(__dirname, "rollup-tx.test.circom");
     let circuit;
 
@@ -33,24 +37,26 @@ describe("Test rollup-tx", function () {
     }
 
     before( async() => {
-        const circuitCode = `
-            include "../src/rollup-tx.circom";
-            component main = RollupTx(${nLevels}, ${nTokens});
-        `;
+        if (!reuse){
+            const circuitCode = `
+                include "../src/rollup-tx.circom";
+                component main = RollupTx(${nLevels}, ${nTokens});
+            `;
 
-        fs.writeFileSync(circuitPath, circuitCode, "utf8");
+            fs.writeFileSync(circuitPath, circuitCode, "utf8");
 
-        circuit = await tester(circuitPath, {reduceConstraints:false});
-        await circuit.loadConstraints();
-        console.log("Constraints: " + circuit.constraints.length + "\n");
-
-        // const testerAux = require("circom").testerAux;
-        // const pathTmp = "/tmp/circom_5800w3wbQYws58WN";
-        // circuit = await testerAux(pathTmp, path.join(__dirname, "circuits", "rollup-tx.test.circom"));
+            circuit = await tester(circuitPath, {reduceConstraints:false});
+            await circuit.loadConstraints();
+            console.log("Constraints: " + circuit.constraints.length + "\n");
+        } else {
+            const testerAux = require("circom").testerAux;
+            circuit = await testerAux(pathTmp, path.join(__dirname, "circuits", "rollup-tx.test.circom"));
+        }
     });
 
     after( async() => {
-        fs.unlinkSync(circuitPath);
+        if (!reuse)
+            fs.unlinkSync(circuitPath);
     });
 
     it("Should check nop tx", async () => {
@@ -918,3 +924,16 @@ describe("Test rollup-tx", function () {
         }
     });
 });
+
+
+// await rollupDB.consolidate(bb3);
+
+//         const stateA = await rollupDB.getStateByIdx(256);
+//         const stateB = await rollupDB.getStateByIdx(257);
+
+//         console.log(stateA);
+//         console.log(`   ${Scalar.fromString(stateA.ay, 16)}`);
+//         console.log(`   ${Scalar.fromString(stateA.ethAddr, 16)}`);
+//         console.log(stateB);
+//         console.log(`   ${Scalar.fromString(stateB.ay, 16)}`);
+//         console.log(`   ${Scalar.fromString(stateB.ethAddr, 16)}`);

--- a/tools/helpers/actions.js
+++ b/tools/helpers/actions.js
@@ -190,7 +190,7 @@ async function generateSolidityVerifier(nTx, nLevels, maxL1Tx, maxFeeTx){
     const solName = `${circuitName}-${nTx}-${nLevels}-${maxL1Tx}-${maxFeeTx}_verifier.sol`;
 
     if (!fs.existsSync(path.join(pathName, zkeyName))) {
-        console.log(`ZKey file ${path.join(pathName,zkeyName)} doesnt exist`);
+        console.log(`ZKey file ${path.join(pathName,zkeyName)} does not exist`);
         return;
     }
 

--- a/tools/reuse-compiled-circuits/README.md
+++ b/tools/reuse-compiled-circuits/README.md
@@ -1,0 +1,11 @@
+# Reuse compiled circuits
+This tool extends functioanility of circom package in order to reuse compiled circuits
+
+## extend functionality
+The following command will copy the necessary files to circom package:
+```
+npm run extend-circom
+```
+
+## how it works
+- every time a new circuit is compiled, the temporary folder where all the circuits are compiled will be shown in the terminal

--- a/tools/reuse-compiled-circuits/files/index.js
+++ b/tools/reuse-compiled-circuits/files/index.js
@@ -1,0 +1,5 @@
+module.exports.compiler = require("./src/compiler.js");
+module.exports.c_tester = require("./ports/c/tester.js");
+module.exports.wasm_tester = require("./ports/wasm/tester.js");
+module.exports.tester = module.exports.wasm_tester;
+module.exports.testerAux = require("./ports/wasm/tester-aux.js");

--- a/tools/reuse-compiled-circuits/files/tester-aux.js
+++ b/tools/reuse-compiled-circuits/files/tester-aux.js
@@ -1,0 +1,226 @@
+const chai = require("chai");
+const assert = chai.assert;
+
+const fs = require("fs");
+const path = require("path");
+
+const utils = require("../../src/utils");
+const loadR1cs = require("r1csfile").load;
+const ZqField = require("ffjavascript").ZqField;
+const fastFile = require("fastfile");
+// const loadSym = require("../../../snarkjs/src/loadsyms");
+
+const WitnessCalculatorBuilder = require("circom_runtime").WitnessCalculatorBuilder;
+
+module.exports = wasm_tester;
+
+async function  wasm_tester(pathCircom, circomFile) {
+    const baseName = path.basename(circomFile, ".circom");
+
+    const wasm = await fs.promises.readFile(path.join(pathCircom, baseName + ".wasm"));
+
+    const witnessOptions = await optionsWitness(path.join(pathCircom, baseName + ".sym"));
+    const wc = await WitnessCalculatorBuilder(wasm, witnessOptions);
+
+    return new WasmTester(pathCircom, baseName, wc);
+}
+
+class WasmTester {
+
+    constructor(path, baseName, witnessCalculator) {
+        this.path = path;
+        this.baseName = baseName;
+        this.witnessCalculator = witnessCalculator;
+    }
+
+    async calculateWitness(input, sanityCheck) {
+        const self = this;
+        if (!self.symbols) await self.loadSymbols();
+        return await this.witnessCalculator.calculateWitness(input, sanityCheck, this.symbols);
+    }
+
+    async loadSymbols() {
+        if (this.symbols) return;
+        this.symbols = {};
+        const symsStr = await fs.promises.readFile(
+            path.join(this.path, this.baseName + ".sym"),
+            "utf8"
+        );
+        const lines = symsStr.split("\n");
+        for (let i=0; i<lines.length; i++) {
+            const arr = lines[i].split(",");
+            if (arr.length!=4) continue;
+            this.symbols[arr[3]] = {
+                labelIdx: Number(arr[0]),
+                varIdx: Number(arr[1]),
+                componentIdx: Number(arr[2]),
+            };
+        }
+    }
+
+    async loadConstraints() {
+        const self = this;
+        if (this.constraints) return;
+        const r1cs = await loadR1cs(path.join(this.path, this.baseName + ".r1cs"),true, false);
+        self.F = new ZqField(r1cs.prime);
+        self.nVars = r1cs.nVars;
+        self.constraints = r1cs.constraints;
+    }
+
+    async assertOut(actualOut, expectedOut) {
+        const self = this;
+        if (!self.symbols) await self.loadSymbols();
+
+        checkObject("main", expectedOut);
+
+        function checkObject(prefix, eOut) {
+
+            if (Array.isArray(eOut)) {
+                for (let i=0; i<eOut.length; i++) {
+                    checkObject(prefix + "["+i+"]", eOut[i]);
+                }
+            } else if ((typeof eOut == "object")&&(eOut.constructor.name == "Object")) {
+                for (let k in eOut) {
+                    checkObject(prefix + "."+k, eOut[k]);
+                }
+            } else {
+                if (typeof self.symbols[prefix] == "undefined") {
+                    assert(false, "Output variable not defined: "+ prefix);
+                }
+                const ba = actualOut[self.symbols[prefix].varIdx].toString();
+                const be = eOut.toString();
+                assert.strictEqual(ba, be, prefix);
+            }
+        }
+    }
+
+    async getSignal(witness, signalName){
+        const self = this;
+        if (!self.symbols) await self.loadSymbols();
+
+        if (typeof self.symbols[signalName] == "undefined") {
+            assert(false, "Output variable not defined: "+ signalName);
+        }
+        return witness[self.symbols[signalName].varIdx];
+    }
+
+    async getDecoratedOutput(witness) {
+        const self = this;
+        const lines = [];
+        if (!self.symbols) await self.loadSymbols();
+        for (let n in self.symbols) {
+            let v;
+            if (utils.isDefined(witness[self.symbols[n].varIdx])) {
+                v = witness[self.symbols[n].varIdx].toString();
+            } else {
+                v = "undefined";
+            }
+            lines.push(`${n} --> ${v}`);
+        }
+        return lines.join("\n");
+    }
+
+    async checkConstraints(witness) {
+        const self = this;
+        if (!self.constraints) await self.loadConstraints();
+        for (let i=0; i<self.constraints.length; i++) {
+            checkConstraint(self.constraints[i]);
+        }
+
+        function checkConstraint(constraint) {
+            const F = self.F;
+            const a = evalLC(constraint[0]);
+            const b = evalLC(constraint[1]);
+            const c = evalLC(constraint[2]);
+
+            assert (F.isZero(F.sub(F.mul(a,b), c)), "Constraint doesn't match");
+        }
+
+        function evalLC(lc) {
+            const F = self.F;
+            let v = F.zero;
+            for (let w in lc) {
+                v = F.add(
+                    v,
+                    F.mul( lc[w], witness[w] )
+                );
+            }
+            return v;
+        }
+    }
+}
+
+async function loadSyms(symFileName){
+    const sym = {
+        labelIdx2Name: [ "one" ],
+        varIdx2Name: [ "one" ],
+        componentIdx2Name: []
+    };
+    const fd = await fastFile.readExisting(symFileName);
+    const buff = await fd.read(fd.totalSize);
+    const symsStr = new TextDecoder("utf-8").decode(buff);
+    const lines = symsStr.split("\n");
+    for (let i=0; i<lines.length; i++) {
+        const arr = lines[i].split(",");
+        if (arr.length!=4) continue;
+        if (sym.varIdx2Name[arr[1]]) {
+            sym.varIdx2Name[arr[1]] += "|" + arr[3];
+        } else {
+            sym.varIdx2Name[arr[1]] = arr[3];
+        }
+        sym.labelIdx2Name[arr[0]] = arr[3];
+        if (!sym.componentIdx2Name[arr[2]]) {
+            sym.componentIdx2Name[arr[2]] = extractComponent(arr[3]);
+        }
+    }
+
+    await fd.close();
+
+    return sym;
+
+    function extractComponent(name) {
+        const arr = name.split(".");
+        arr.pop(); // Remove the lasr element
+        return arr.join(".");
+    }
+}
+
+async function optionsWitness(symFileName){
+    const options = {
+        set: false,
+        get: false,
+        trigger: false,
+    }
+    
+    
+    let wcOps = {
+        sanityCheck: true
+    };
+    let sym = await loadSyms(symFileName);
+    
+    if (options.set) {
+        if (!sym) sym = await loadSyms(symFileName);
+        wcOps.logSetSignal= function(labelIdx, value) {
+            console.log("SET " + sym.labelIdx2Name[labelIdx] + " <-- " + value.toString());
+        };
+    }
+
+    if (options.get) {
+        if (!sym) sym = await loadSyms(symFileName);
+        wcOps.logGetSignal= function(varIdx, value) {
+            console.log("GET " + sym.labelIdx2Name[varIdx] + " --> " + value.toString());
+        };
+    }
+
+    if (options.trigger) {
+        if (!sym) sym = await loadSyms(symFileName);
+        wcOps.logStartComponent= function(cIdx) {
+            console.log("START: " + sym.componentIdx2Name[cIdx]);
+        };
+        wcOps.logFinishComponent= function(cIdx) {
+            console.log("FINISH: " + sym.componentIdx2Name[cIdx]);
+       };
+    }
+    
+    return wcOps;
+}

--- a/tools/reuse-compiled-circuits/files/tester.js
+++ b/tools/reuse-compiled-circuits/files/tester.js
@@ -1,0 +1,252 @@
+const chai = require("chai");
+const assert = chai.assert;
+
+const fs = require("fs");
+var tmp = require("tmp-promise");
+const path = require("path");
+const compiler = require("../../src/compiler");
+
+const utils = require("../../src/utils");
+const loadR1cs = require("r1csfile").load;
+const ZqField = require("ffjavascript").ZqField;
+const fastFile = require("fastfile");
+
+const WitnessCalculatorBuilder = require("circom_runtime").WitnessCalculatorBuilder;
+
+module.exports = wasm_tester;
+
+async function  wasm_tester(circomFile, _options) {
+    // tmp.setGracefulCleanup();
+
+    const dir = await tmp.dir({prefix: "circom_", unsafeCleanup: true });
+
+    console.log(dir.path);
+
+    const baseName = path.basename(circomFile, ".circom");
+    const options = Object.assign({}, _options);
+
+    // options.wasmFile = await fastFile.createOverride(path.join(dir.path, baseName + ".wasm"));
+    options.wasmFileName = path.join(dir.path, baseName + ".wasm");
+
+    options.symWriteStream = fs.createWriteStream(path.join(dir.path, baseName + ".sym"));
+    options.r1csFileName = path.join(dir.path, baseName + ".r1cs");
+
+    if (options.n) {
+        options.newThreadTemplates = new RegExp(options.n);
+    }
+
+    await compiler(circomFile, options);
+
+    // await options.wasmFile.close();
+
+    const wasm = await fs.promises.readFile(path.join(dir.path, baseName + ".wasm"));
+
+    const witnessOptions = await optionsWitness(path.join(dir.path, baseName + ".sym"));
+
+    const wc = await WitnessCalculatorBuilder(wasm, witnessOptions);
+
+    return new WasmTester(dir, baseName, wc);
+}
+
+class WasmTester {
+
+    constructor(dir, baseName, witnessCalculator) {
+        this.dir=dir;
+        this.baseName = baseName;
+        this.witnessCalculator = witnessCalculator;
+    }
+
+    async release() {
+        await this.dir.cleanup();
+    }
+
+    async calculateWitness(input, sanityCheck) {
+        return await this.witnessCalculator.calculateWitness(input, sanityCheck);
+    }
+
+    async loadSymbols() {
+        if (this.symbols) return;
+        this.symbols = {};
+        const symsStr = await fs.promises.readFile(
+            path.join(this.dir.path, this.baseName + ".sym"),
+            "utf8"
+        );
+        const lines = symsStr.split("\n");
+        for (let i=0; i<lines.length; i++) {
+            const arr = lines[i].split(",");
+            if (arr.length!=4) continue;
+            this.symbols[arr[3]] = {
+                labelIdx: Number(arr[0]),
+                varIdx: Number(arr[1]),
+                componentIdx: Number(arr[2]),
+            };
+        }
+    }
+
+    async loadConstraints() {
+        const self = this;
+        if (this.constraints) return;
+        const r1cs = await loadR1cs(path.join(this.dir.path, this.baseName + ".r1cs"),true, false);
+        self.F = new ZqField(r1cs.prime);
+        self.nVars = r1cs.nVars;
+        self.constraints = r1cs.constraints;
+    }
+
+    async assertOut(actualOut, expectedOut) {
+        const self = this;
+        if (!self.symbols) await self.loadSymbols();
+
+        checkObject("main", expectedOut);
+
+        function checkObject(prefix, eOut) {
+
+            if (Array.isArray(eOut)) {
+                for (let i=0; i<eOut.length; i++) {
+                    checkObject(prefix + "["+i+"]", eOut[i]);
+                }
+            } else if ((typeof eOut == "object")&&(eOut.constructor.name == "Object")) {
+                for (let k in eOut) {
+                    checkObject(prefix + "."+k, eOut[k]);
+                }
+            } else {
+                if (typeof self.symbols[prefix] == "undefined") {
+                    assert(false, "Output variable not defined: "+ prefix);
+                }
+                const ba = actualOut[self.symbols[prefix].varIdx].toString();
+                const be = eOut.toString();
+                assert.strictEqual(ba, be, prefix);
+            }
+        }
+    }
+
+    async getSignal(witness, signalName){
+        const self = this;
+        if (!self.symbols) await self.loadSymbols();
+
+        if (typeof self.symbols[signalName] == "undefined") {
+            assert(false, "Output variable not defined: "+ signalName);
+        }
+        return witness[self.symbols[signalName].varIdx];
+    }
+    
+    async getDecoratedOutput(witness) {
+        const self = this;
+        const lines = [];
+        if (!self.symbols) await self.loadSymbols();
+        for (let n in self.symbols) {
+            let v;
+            if (utils.isDefined(witness[self.symbols[n].varIdx])) {
+                v = witness[self.symbols[n].varIdx].toString();
+            } else {
+                v = "undefined";
+            }
+            lines.push(`${n} --> ${v}`);
+        }
+        return lines.join("\n");
+    }
+
+    async checkConstraints(witness) {
+        const self = this;
+        if (!self.constraints) await self.loadConstraints();
+        for (let i=0; i<self.constraints.length; i++) {
+            checkConstraint(self.constraints[i]);
+        }
+
+        function checkConstraint(constraint) {
+            const F = self.F;
+            const a = evalLC(constraint[0]);
+            const b = evalLC(constraint[1]);
+            const c = evalLC(constraint[2]);
+
+            assert (F.isZero(F.sub(F.mul(a,b), c)), "Constraint doesn't match");
+        }
+
+        function evalLC(lc) {
+            const F = self.F;
+            let v = F.zero;
+            for (let w in lc) {
+                v = F.add(
+                    v,
+                    F.mul( lc[w], witness[w] )
+                );
+            }
+            return v;
+        }
+    }
+
+}
+
+async function loadSyms(symFileName){
+    const sym = {
+        labelIdx2Name: [ "one" ],
+        varIdx2Name: [ "one" ],
+        componentIdx2Name: []
+    };
+    const fd = await fastFile.readExisting(symFileName);
+    const buff = await fd.read(fd.totalSize);
+    const symsStr = new TextDecoder("utf-8").decode(buff);
+    const lines = symsStr.split("\n");
+    for (let i=0; i<lines.length; i++) {
+        const arr = lines[i].split(",");
+        if (arr.length!=4) continue;
+        if (sym.varIdx2Name[arr[1]]) {
+            sym.varIdx2Name[arr[1]] += "|" + arr[3];
+        } else {
+            sym.varIdx2Name[arr[1]] = arr[3];
+        }
+        sym.labelIdx2Name[arr[0]] = arr[3];
+        if (!sym.componentIdx2Name[arr[2]]) {
+            sym.componentIdx2Name[arr[2]] = extractComponent(arr[3]);
+        }
+    }
+
+    await fd.close();
+
+    return sym;
+
+    function extractComponent(name) {
+        const arr = name.split(".");
+        arr.pop(); // Remove the lasr element
+        return arr.join(".");
+    }
+}
+
+async function optionsWitness(symFileName){
+    const options = {
+        set: false,
+        get: false,
+        trigger: false,
+    }
+    
+    
+    let wcOps = {
+        sanityCheck: true
+    };
+    let sym = await loadSyms(symFileName);
+    
+    if (options.set) {
+        if (!sym) sym = await loadSyms(symFileName);
+        wcOps.logSetSignal= function(labelIdx, value) {
+            console.log("SET " + sym.labelIdx2Name[labelIdx] + " <-- " + value.toString());
+        };
+    }
+
+    if (options.get) {
+        if (!sym) sym = await loadSyms(symFileName);
+        wcOps.logGetSignal= function(varIdx, value) {
+            console.log("GET " + sym.labelIdx2Name[varIdx] + " --> " + value.toString());
+        };
+    }
+
+    if (options.trigger) {
+        if (!sym) sym = await loadSyms(symFileName);
+        wcOps.logStartComponent= function(cIdx) {
+            console.log("START: " + sym.componentIdx2Name[cIdx]);
+        };
+        wcOps.logFinishComponent= function(cIdx) {
+            console.log("FINISH: " + sym.componentIdx2Name[cIdx]);
+       };
+    }
+    
+    return wcOps;
+}

--- a/tools/reuse-compiled-circuits/reuse-circuits.js
+++ b/tools/reuse-compiled-circuits/reuse-circuits.js
@@ -1,0 +1,21 @@
+const fs = require("fs");
+const path = require("path");
+
+async function main(){
+    const pathCircom = path.join(__dirname, "../../node_modules/circom");
+
+    const pathIndex = path.join(__dirname, "./files/index.js");
+    const pathTester = path.join(__dirname, "./files/tester.js");
+    const pathTesterAux = path.join(__dirname, "./files/tester-aux.js");
+
+    if (!fs.existsSync(pathCircom)){
+        console.log("Circom path does not exit. Install dependencies with `npm run setup`");
+        process.exit(1);
+    }
+
+    fs.copyFileSync(pathIndex, path.join(pathCircom, "./index.js"));
+    fs.copyFileSync(pathTester, path.join(pathCircom, "./ports/wasm/tester.js"));
+    fs.copyFileSync(pathTesterAux, path.join(pathCircom, "./ports/wasm/tester-aux.js"));
+}
+
+main();


### PR DESCRIPTION
This PR does the following:
- updates circuits to remove the exit-tree
- add `accumulatedHash` and `exitBalance`
- add option to extend circom to debug properly and reuse compiled circuits

## Update circuits summary
### balance-updater
- add computing exitBalance for receiver leaf if transaction is an exit 
- remove unnecessary signal `isP2Nop`
### decode-tx
- add computation of L1L2TxsData in integer
### fee-tx
- update leaf with `exitBlance` and `accumulatedHash`
### hash-inputs
- remove `exitRoot`
### rollup-main
- remove intermnediary signal `imExitRoot`
- remove `newExit` flag
- remove signals for inserts on Processor2: `isOld0_2`, `oldKey2` & `oldValue2`
- add new state fields: `exitBalance` & `accumulatedHash`
- L1L2TxsData is 0 if transaction is `onChain`
### rollup-tx-states
- remove insertions on processor2
- update processor2 functions
### rollup-tx
- compute accumulated hash
- remove selectors when processor2 was performing an insert
- remove exit root computation

## Extend circom
- `npm run extend-circom` will add extra functionality to circom in order to debug circuits
- `reuse` and `pathTmp` should be set correctly if a circuit wants to be reused

close #38 