### PR TITLE
implement upgrade-root circuit

### DIFF
--- a/js/upgrade-db.js
+++ b/js/upgrade-db.js
@@ -11,7 +11,7 @@ class UpgradeDb {
 
     /**
      * constructor
-     * @param {Object} rollupDb - RollupDb with ols accounts
+     * @param {Object} rollupDb - RollupDb with old accounts
      * @param {Number} nAccounts - maximum accounts to update in each proof
      * @param {Number} nLevels - merkle tree depth
      */
@@ -41,12 +41,12 @@ class UpgradeDb {
      */
     async doUpgrade(){
         let initKeyStateTree;
-        let finalKeystateTree;
+        let finalKeyStateTree;
 
         for (let i = 0; i < this.numProofs; i++){
             initKeyStateTree = this.initIdx + i*this.nAccounts;
-            finalKeystateTree = this.initIdx + (i+1)*this.nAccounts;
-            await this._buildSingleProof(initKeyStateTree, finalKeystateTree);
+            finalKeyStateTree = this.initIdx + (i+1)*this.nAccounts;
+            await this._buildSingleProof(initKeyStateTree, finalKeyStateTree);
         }
 
         this.isUpgraded = true;
@@ -152,13 +152,7 @@ class UpgradeDb {
      * @returns {Object} proof input
      */
     getProof(numProof){
-        if (!this.isUpgraded){
-            throw new Error("Upgrade has not been performed");
-        }
-
-        if (numProof > this.numProofs){
-            throw new Error(`Proof ${numProof} is greater than total necessary proofs, ${this.numProofs}`);
-        }
+        this._sanityCheck(numProof);
 
         return this.proofs[numProof];
     }

--- a/js/upgrade-db.js
+++ b/js/upgrade-db.js
@@ -1,0 +1,240 @@
+const Scalar = require("ffjavascript").Scalar;
+const commonjs = require("@hermeznetwork/commonjs");
+const commonjsOld = require("@hermeznetwork/commonjs-old");
+const SMT = require("circomlib").SMT;
+const poseidonHash = require("circomlib").poseidon;
+
+/**
+ * Upgrade rollupDb account to v1
+ */
+class UpgradeDb {
+
+    /**
+     * constructor
+     * @param {Object} rollupDb - RollupDb with ols accounts
+     * @param {Number} nAccounts - maximum accounts to update in each proof
+     * @param {Number} nLevels - merkle tree depth
+     */
+    constructor(rollupDb, nAccounts, nLevels){
+        this.rollupDb = rollupDb;
+        this.nAccounts = nAccounts;
+        this.maxIdx = this.rollupDb.initialIdx;
+        this.initIdx = commonjs.Constants.firstIdx + 1;
+        this.isUpgraded = false;
+        this.lastBatch = this.rollupDb.lastBatch;
+        this.nLevels = nLevels;
+
+        // compute number of proofs to build
+        this.numProofs = Math.ceil((this.maxIdx - this.initIdx + 1) / this.nAccounts);
+        this.proofs = [];
+        this.newStateRoots = [];
+        this.finalIdxs = [];
+        this.imStateRoots = [];
+        this.imFinalIdxs = [];
+
+        this.dbState = new commonjs.SMTTmpDb(this.rollupDb.db);
+        this.stateTree = new SMT(this.dbState, this.rollupDb.stateRoot);
+    }
+
+    /**
+     * Perform upgrade for each account to new leaf state
+     */
+    async doUpgrade(){
+        let initKeyStateTree;
+        let finalKeystateTree;
+
+        for (let i = 0; i < this.numProofs; i++){
+            initKeyStateTree = this.initIdx + i*this.nAccounts;
+            finalKeystateTree = this.initIdx + (i+1)*this.nAccounts;
+            await this._buildSingleProof(initKeyStateTree, finalKeystateTree);
+        }
+
+        this.isUpgraded = true;
+    }
+
+    /**
+     * Build single proof for upgrading accounts
+     * @param {Number} initKey - first key to update
+     * @param {Number} finalKey - last key to update
+     */
+    async _buildSingleProof(initKey, finalKey){
+        const input = this._initInput();
+        const imStateRoot = [];
+        const imFinalIdx = [];
+        this.finalIdxs.push((finalKey < this.maxIdx) ? finalKey : this.maxIdx + 1);
+
+        input.initialIdx = initKey;
+        input.maxIdx = this.maxIdx;
+        input.oldStateRoot = this.stateTree.root;
+
+        for (let i = initKey; i < finalKey; i++){
+            const k = i - initKey;
+
+            if (i <= this.maxIdx){
+                // get old state
+                let oldState;
+                const resFind = await this.stateTree.find(i);
+                if (resFind.found) {
+                    const foundValueId = poseidonHash([resFind.foundValue, i]);
+                    oldState = commonjsOld.stateUtils.array2State(await this.dbState.get(foundValueId));
+                } else {
+                    throw new Error(`Unreacheable code: key state tree ${i} does not exist`);
+                }
+
+                // set new state
+                const newState = Object.assign({}, oldState);
+                newState.exitBalance = 0;
+                newState.accumulatedHash = 0;
+                const newValue = commonjs.stateUtils.hashState(newState);
+
+                const res = await this.stateTree.update(i, newValue);
+                let siblings = res.siblings;
+                while (siblings.length < this.nLevels + 1) siblings.push(Scalar.e(0));
+                // fill inputs
+                input.tokenID[k] = Scalar.e(oldState.tokenID);
+                input.nonce[k] = Scalar.e(oldState.nonce);
+                input.sign[k] = Scalar.e(oldState.sign);
+                input.balance[k] = Scalar.e(oldState.balance);
+                input.ay[k] = Scalar.fromString(oldState.ay, 16);
+                input.ethAddr[k] = Scalar.fromString(oldState.ethAddr, 16);
+                input.siblings[k] = siblings;
+
+                imFinalIdx[k] = i+1;
+                imStateRoot[k] = this.stateTree.root;
+
+            } else {
+                input.tokenID[k] = 0;
+                input.nonce[k] = 0;
+                input.sign[k] = 0;
+                input.balance[k] = 0;
+                input.ay[k] = 0;
+                input.ethAddr[k] = 0;
+                input.siblings[k] = [];
+                for (let j = 0; j < this.nLevels + 1; j++) {
+                    input.siblings[k][j] = 0;
+                }
+
+                imFinalIdx[k] = i;
+                imStateRoot[k] = this.stateTree.root;
+            }
+        }
+
+        this.imFinalIdxs.push(imFinalIdx);
+        this.imStateRoots.push(imStateRoot);
+
+        this.proofs.push(input);
+        this.newStateRoots.push(this.stateTree.root);
+    }
+
+    /**
+     * creates an empty input
+     * @returns {Object} empty input
+     */
+    _initInput(){
+        return {
+            initialIdx: 0,
+            maxIdx: 0,
+            oldStateRoot: 0,
+
+            tokenID: [],
+            nonce: [],
+            sign: [],
+            balance: [],
+            ay: [],
+            ethAddr: [],
+            siblings: []
+        };
+    }
+
+    /**
+     * Retrieve full proof
+     * @param {Number} numProof - proof number
+     * @returns {Object} proof input
+     */
+    getProof(numProof){
+        if (!this.isUpgraded){
+            throw new Error("Upgrade has not been performed");
+        }
+
+        if (numProof > this.numProofs){
+            throw new Error(`Proof ${numProof} is greater than total necessary proofs, ${this.numProofs}`);
+        }
+
+        return this.proofs[numProof];
+    }
+
+    /**
+     * Retrieve new state root
+     * @param {Number} numProof - proof number
+     * @returns {Scalar} new state root
+     */
+    getNewStateRoot(numProof){
+        this._sanityCheck(numProof);
+
+        return this.newStateRoots[numProof];
+    }
+
+    /**
+     * Retrieve intermediates state roots
+     * @param {Number} numProof - proof number
+     * @returns {Scalar} intermediate states root
+     */
+    getImStateRoot(numProof){
+        this._sanityCheck(numProof);
+
+        return this.imStateRoots[numProof];
+    }
+
+    /**
+     * Retrieve last idx updated
+     * @param {Number} numProof - proof number
+     * @returns {Number} last idx updated
+     */
+    getFinalIdxs(numProof){
+        this._sanityCheck(numProof);
+
+        return this.finalIdxs[numProof];
+    }
+
+    /**
+     * Retrieve intermediate last idx updated
+     * @param {Number} numProof - proof number
+     * @returns {Number} intermediate last idx updated
+     */
+    getImFinalIdxs(numProof){
+        this._sanityCheck(numProof);
+
+        return this.imFinalIdxs[numProof];
+    }
+
+    /**
+     * Retrieve output for each proof
+     * @param {Number} numProof - proof number
+     * @returns {Object} output proof
+     */
+    getOutput(numProof){
+        this._sanityCheck(numProof);
+        const output = {
+            newStateRoot: this.getNewStateRoot(numProof),
+            finalIdx: this.getFinalIdxs(numProof)
+        };
+
+        return output;
+    }
+
+    /**
+     * Check rollupDb has been upgraded and proof number is valid
+     * @param {Number} numProof - proof number
+     */
+    _sanityCheck(numProof){
+        if (!this.isUpgraded){
+            throw new Error("Upgrade has not been performed");
+        }
+
+        if (numProof > this.numProofs){
+            throw new Error(`Proof ${numProof} is greater than total necessary proofs, ${this.numProofs}`);
+        }
+    }
+}
+
+module.exports = UpgradeDb;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@hermeznetwork/commonjs": "^0.3.3",
+        "@hermeznetwork/commonjs-old": "git+https://github.com/hermeznetwork/commonjs.git#72db600",
         "circom": "^0.5.45",
         "circom_runtime": "^0.1.9",
         "circomlib": "^0.5.2",
@@ -434,6 +435,22 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@hermeznetwork/commonjs/-/commonjs-0.3.3.tgz",
       "integrity": "sha512-0HLBbsuPFFWxU33Cei3/BmpubPpYSKgQraJkDq53yaZhaVhcTbe5DcOvBX3dzxnG2Faz39eFqTxRV+4PYPTomg==",
+      "dependencies": {
+        "chai": "^4.2.0",
+        "circomlib": "^0.5.0",
+        "elliptic": "^6.5.3",
+        "ethers": "5.0.24",
+        "ffjavascript": "^0.2.33",
+        "js-sha3": "^0.8.0",
+        "level": "^6.0.1",
+        "web3-utils": "^1.2.11"
+      }
+    },
+    "node_modules/@hermeznetwork/commonjs-old": {
+      "name": "@hermeznetwork/commonjs",
+      "version": "0.3.3",
+      "resolved": "git+ssh://git@github.com/hermeznetwork/commonjs.git#72db600eb8ab82d063698eaf6913afb966241223",
+      "license": "AGPL-3.0",
       "dependencies": {
         "chai": "^4.2.0",
         "circomlib": "^0.5.0",
@@ -4752,6 +4769,20 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@hermeznetwork/commonjs/-/commonjs-0.3.3.tgz",
       "integrity": "sha512-0HLBbsuPFFWxU33Cei3/BmpubPpYSKgQraJkDq53yaZhaVhcTbe5DcOvBX3dzxnG2Faz39eFqTxRV+4PYPTomg==",
+      "requires": {
+        "chai": "^4.2.0",
+        "circomlib": "^0.5.0",
+        "elliptic": "^6.5.3",
+        "ethers": "5.0.24",
+        "ffjavascript": "^0.2.33",
+        "js-sha3": "^0.8.0",
+        "level": "^6.0.1",
+        "web3-utils": "^1.2.11"
+      }
+    },
+    "@hermeznetwork/commonjs-old": {
+      "version": "git+ssh://git@github.com/hermeznetwork/commonjs.git#72db600eb8ab82d063698eaf6913afb966241223",
+      "from": "@hermeznetwork/commonjs-old@git+https://github.com/hermeznetwork/commonjs.git#72db600",
       "requires": {
         "chai": "^4.2.0",
         "circomlib": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@hermeznetwork/commonjs": "^0.3.3",
+    "@hermeznetwork/commonjs-old": "git+https://github.com/hermeznetwork/commonjs.git#72db600",
     "circom": "^0.5.45",
     "circom_runtime": "^0.1.9",
     "circomlib": "^0.5.2",

--- a/src/lib/hash-state-old.circom
+++ b/src/lib/hash-state-old.circom
@@ -1,0 +1,40 @@
+include "../../node_modules/circomlib/circuits/poseidon.circom";
+
+/**
+ * Computes the hash of an account state
+ * State Hash = Poseidon(e0, e1, e2, e3)
+ * e0: sign(1 bit) | nonce(40bits) | tokenID(32 bits)
+ * e1: balance
+ * e2: ay
+ * e3: ethAddr
+ * @input tokenID - {Uint32} - token identifier
+ * @input nonce - {Uint40} - nonce
+ * @input sign - {Bool} - babyjubjub sign
+ * @input balance - {Uint192} - account balance
+ * @input ay - {Field} - babyjubjub Y coordinate
+ * @input ethAddr - {Uint160} - etehreum address
+ * @output out - {Field} - resulting poseidon hash
+ */
+template HashStateOld() {
+    signal input tokenID;
+    signal input nonce;
+    signal input sign;
+    signal input balance;
+    signal input ay;
+    signal input ethAddr;
+
+    signal output out;
+
+    signal e0; // build e0 element
+
+    e0 <== tokenID + nonce * (1 << 32) + sign * (1 << 72);
+
+    component hash = Poseidon(4);
+
+    hash.inputs[0] <== e0;
+    hash.inputs[1] <== balance;
+    hash.inputs[2] <== ay;
+    hash.inputs[3] <== ethAddr;
+
+    hash.out ==> out;
+}

--- a/src/rollup-tx.circom
+++ b/src/rollup-tx.circom
@@ -484,7 +484,7 @@ template RollupTx(nLevels, maxFeeTx) {
     // J - smt processors
     ////////
     // processor 1: sender
-    component processor1 = SMTProcessor(nLevels+1) ;
+    component processor1 = SMTProcessor(nLevels+1);
     processor1.oldRoot <== oldStateRoot;
     for (i = 0; i < nLevels + 1; i++) {
         processor1.siblings[i] <== siblings1[i];
@@ -498,7 +498,7 @@ template RollupTx(nLevels, maxFeeTx) {
     processor1.fnc[1] <== states.P1_fnc1;
 
     // processor 2: receiver
-    component processor2 = SMTProcessor(nLevels+1) ;
+    component processor2 = SMTProcessor(nLevels+1);
     processor2.oldRoot <== processor1.newRoot;
     for (i = 0; i < nLevels + 1; i++) {
         processor2.siblings[i] <== siblings2[i];

--- a/src/upgrade-root/upgrade-root.circom
+++ b/src/upgrade-root/upgrade-root.circom
@@ -1,0 +1,76 @@
+include "../../node_modules/circomlib/circuits/comparators.circom";
+include "../../node_modules/circomlib/circuits/poseidon.circom";
+include "../../node_modules/circomlib/circuits/smt/smtprocessor.circom";
+include "../../node_modules/circomlib/circuits/smt/smtverifier.circom";
+include "../../node_modules/circomlib/circuits/sha256/sha256.circom";
+
+include "./upgrade-step.circom"
+
+/**
+ * Upgrade state root account by account
+ * @param nLevels - merkle tree depth
+ * @param nAccounts - accounts to update
+ * @input initialIdx - {Uint48} - first account to update
+ * @input maxIdx - {Field} - maximum account to update
+ * @input oldStateRoot - {Field} - initial state root
+ * @input tokenID[nAccounts] - {Array(Uint32)} - tokenID of the account to update
+ * @input nonce[nAccounts] - {Array(Uint40)} - nonce of the account to update
+ * @input sign[nAccounts] - {Array(Bool)} - sign of the account to update
+ * @input balance[nAccounts] - {Array(Uint192)} - balance of the account to update
+ * @input ay[nAccounts] - {Array(Field)} - ay of the account to update
+ * @input ethAddr[nAccounts] - {Array(Uint160)} - ethAddr of the account to update
+ * @input siblings[nAccounts][nLevels + 1] - {Array[Array(Field)]} - siblings merkle proof account to update
+ * @output finalIdx - {Uint48} - last account that has been updated
+ * @output newStateRoot - {Field} - last state root after account updating
+ */
+template UpgradeRoot(nLevels, nAccounts) {
+
+    signal input initialIdx;
+    signal output finalIdx;
+
+    signal input maxIdx;
+
+    signal input oldStateRoot;
+    signal output newStateRoot;
+
+    // private inputs old state
+	signal private input tokenID[nAccounts];
+    signal private input nonce[nAccounts];
+    signal private input sign[nAccounts];
+    signal private input balance[nAccounts];
+    signal private input ay[nAccounts];
+    signal private input ethAddr[nAccounts];
+    signal private input siblings[nAccounts][nLevels + 1];
+
+    var i;
+    var j;
+
+    component upgradeStep[nAccounts];
+
+    for (i = 0; i < nAccounts; i++){
+        upgradeStep[i] = UpgradeStep(nLevels);
+
+        if (i == 0){
+            upgradeStep[i].inIdx <== initialIdx;
+            upgradeStep[i].inStateRoot <== oldStateRoot;
+        } else {
+            upgradeStep[i].inIdx <== upgradeStep[i-1].outIdx;
+            upgradeStep[i].inStateRoot <== upgradeStep[i-1].outStateRoot;
+        }
+
+        upgradeStep[i].maxIdx <== maxIdx;
+        upgradeStep[i].tokenID <== tokenID[i];
+        upgradeStep[i].nonce <== nonce[i];
+        upgradeStep[i].sign <== sign[i];
+        upgradeStep[i].balance <== balance[i];
+        upgradeStep[i].ay <== ay[i];
+        upgradeStep[i].ethAddr <== ethAddr[i];
+
+        for (j = 0; j < nLevels+1; j++) {
+            upgradeStep[i].siblingsState[j] <== siblings[i][j];
+        }
+    }
+
+    finalIdx <== upgradeStep[nAccounts-1].outIdx;
+    newStateRoot <== upgradeStep[nAccounts-1].outStateRoot;
+}

--- a/src/upgrade-root/upgrade-step.circom
+++ b/src/upgrade-root/upgrade-step.circom
@@ -1,0 +1,89 @@
+include "../../node_modules/circomlib/circuits/comparators.circom";
+include "../../node_modules/circomlib/circuits/poseidon.circom";
+include "../../node_modules/circomlib/circuits/smt/smtprocessor.circom";
+include "../../node_modules/circomlib/circuits/smt/smtverifier.circom";
+include "../../node_modules/circomlib/circuits/sha256/sha256.circom";
+
+include "../lib/hash-state.circom"
+include "../lib/hash-state-old.circom";
+
+/**
+ * Upgrade state root account step
+ * @param nLevels - merkle tree depth
+ * @input maxIdx - {Field} - maximum account to update
+ * @input inIdx - {Uint48} - account to update
+ * @input inStateRoot - {Field} - initial state root
+ * @input tokenID - {Uint32} - tokenID of the account to update
+ * @input nonce - {Uint40} - nonce of the account to update
+ * @input sign - {Bool} - sign of the account to update
+ * @input balance - {Uint192} - balance of the account to update
+ * @input ay - {Field} - ay of the account to update
+ * @input ethAddr - {Uint160} - ethAddr of the account to update
+ * @input siblingsState[nLevels + 1] - {Array(Field)} - siblings merkle proof account to update
+ * @output outIdx - {Uint48} - next account to update
+ * @output outStateRoot - {Field} - state root after account updating
+ */
+template UpgradeStep(nLevels) {
+    signal input maxIdx;
+
+    signal input inIdx;
+    signal output outIdx;
+
+    signal input inStateRoot;
+    signal output outStateRoot;
+
+    signal private input tokenID;
+    signal private input nonce;
+    signal private input sign;
+    signal private input balance;
+    signal private input ay;
+    signal private input ethAddr;
+    signal private input siblingsState[nLevels + 1];
+
+    var i;
+
+    // checks: inIdx > maxIdx
+    component reachMaxIdx = GreaterThan(40);
+    reachMaxIdx.in[0] <== inIdx;
+    reachMaxIdx.in[1] <== maxIdx;
+
+    // compute old account state hash
+    ////////
+    component oldAccountState = HashStateOld();
+    oldAccountState.tokenID <== tokenID;
+    oldAccountState.nonce <== nonce;
+    oldAccountState.sign <== sign;
+    oldAccountState.balance <== balance;
+    oldAccountState.ay <== ay;
+    oldAccountState.ethAddr <== ethAddr;
+
+    // compute new account state hash
+    ////////
+    component newAccountState = HashState();
+    newAccountState.tokenID <== tokenID;
+    newAccountState.nonce <== nonce;
+    newAccountState.sign <== sign;
+    newAccountState.balance <== balance;
+    newAccountState.ay <== ay;
+    newAccountState.ethAddr <== ethAddr;
+    newAccountState.exitBalance <== 0;
+    newAccountState.accumulatedHash <== 0;
+
+    // process new state root
+    ////////
+    component processor = SMTProcessor(nLevels+1) ;
+    processor.oldRoot <== inStateRoot;
+    for (i = 0; i < nLevels + 1; i++) {
+        processor.siblings[i] <== siblingsState[i];
+    }
+    processor.oldKey <== inIdx;
+    processor.oldValue <== oldAccountState.out;
+    processor.isOld0 <== 0;
+    processor.newKey <== inIdx;
+    processor.newValue <== newAccountState.out;
+    processor.fnc[0] <== 0;
+    processor.fnc[1] <== 1 - reachMaxIdx.out;
+
+    outStateRoot <== processor.newRoot;
+    outIdx <== inIdx + (1 - reachMaxIdx.out);
+}

--- a/test/upgrade-root/helpers-upgrade/helpers-upgrade.js
+++ b/test/upgrade-root/helpers-upgrade/helpers-upgrade.js
@@ -1,0 +1,71 @@
+/**
+ * Retrieve proof for single step
+ * @param {Object} upgradeDb - updareDb Class
+ * @param {Number} numProof  - proof number
+ * @param {Number} i - relative account index
+ * @returns {Object} - input and output for upgrade-step circuit
+ */
+async function getSingleUpgradeStep(upgradeDb, numProof, i){
+    const fullInput = upgradeDb.getProof(numProof);
+
+    const imFinalIdxs = upgradeDb.getImFinalIdxs(numProof);
+    const imStateRoot = upgradeDb.getImStateRoot(numProof);
+
+    // build input step
+    const input = {
+        maxIdx: fullInput.maxIdx,
+        inIdx: i == 0 ? fullInput.initialIdx : imFinalIdxs[i - 1],
+        inStateRoot: i == 0 ? fullInput.oldStateRoot : imStateRoot[i - 1],
+        tokenID: fullInput.tokenID[i],
+        nonce: fullInput.nonce[i],
+        sign: fullInput.sign[i],
+        balance: fullInput.balance[i],
+        ay: fullInput.ay[i],
+        ethAddr: fullInput.ethAddr[i],
+        siblingsState: fullInput.siblings[i],
+    };
+
+    const output = {
+        outIdx: imFinalIdxs[i],
+        outStateRoot: imStateRoot[i],
+    };
+
+    return { input, output };
+}
+
+/**
+ * Assert upgrade-step proof input
+ * @param {Object} upgradeDb - upgradeDb Class
+ * @param {Object} circuit - circuit compiled
+ */
+async function assertUpgradeSteps(upgradeDb, circuit){
+    const numProofs = upgradeDb.numProofs;
+    const nAccounts = upgradeDb.nAccounts;
+
+    for (let i = 0; i < numProofs; i++){
+        for (let j = 0; j < nAccounts; j++){
+            const res = await getSingleUpgradeStep(upgradeDb, i, j);
+            const w = await circuit.calculateWitness(res.input, {logTrigger:false, logOutput: false, logSet: false});
+            await circuit.assertOut(w, res.output);
+        }
+    }
+}
+
+/**
+ * Assert upgrade-root proof
+ * @param {Object} upgradeDb - upgradeDb Class
+ * @param {Object} circuit - circuit compiled
+ */
+async function assertUpgradeRoot(upgradeDb, circuit){
+    for (let i = 0; i < upgradeDb.numProofs; i++){
+        const input = await upgradeDb.getProof(i);
+        const output = await upgradeDb.getOutput(i);
+        const w = await circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        await circuit.assertOut(w, output);
+    }
+}
+
+module.exports = {
+    assertUpgradeSteps,
+    assertUpgradeRoot
+};

--- a/test/upgrade-root/upgrade-root.test.js
+++ b/test/upgrade-root/upgrade-root.test.js
@@ -1,0 +1,133 @@
+const { expect } = require("chai");
+const fs = require("fs");
+const path = require("path");
+const tester = require("circom").tester;
+const Scalar = require("ffjavascript").Scalar;
+const SMTMemDB = require("circomlib").SMTMemDB;
+
+const commonjsOld = require("@hermeznetwork/commonjs-old");
+const RollupDB = require("@hermeznetwork/commonjs").RollupDB;
+const Account = require("@hermeznetwork/commonjs").HermezAccount;
+const Constants = require("@hermeznetwork/commonjs").Constants;
+const txUtils = require("@hermeznetwork/commonjs").txUtils;
+const float40 = require("@hermeznetwork/commonjs").float40;
+
+const { depositTx, printSignals } = require("../helpers/helpers");
+const { assertUpgradeRoot } = require("./helpers-upgrade/helpers-upgrade");
+const UpgradeDb = require("../../js/upgrade-db");
+
+describe("Test upgrade-root", function () {
+    this.timeout(0);
+
+    const reuse = false;
+    const pathTmp = "/tmp/circom_14676q9wEzEedL20V";
+
+    let circuitPath = path.join(__dirname, "upgrade-root.test.circom");
+    let circuit;
+
+    const nAccountsUpgrade = 4;
+
+    const nTx = 10;
+    const nLevels = 16;
+    const maxL1Tx = 5;
+    const maxFeeTx = 5;
+
+    const numInitAccounts = 100;
+    const accounts = [];
+
+    before( async() => {
+        if (!reuse){
+            const circuitCode = `
+                include "../../src/upgrade-root/upgrade-root.circom";
+                component main = UpgradeRoot(${nLevels}, ${nAccountsUpgrade});
+            `;
+
+            fs.writeFileSync(circuitPath, circuitCode, "utf8");
+
+            circuit = await tester(circuitPath, {reduceConstraints:false});
+            await circuit.loadConstraints();
+            console.log("Constraints: " + circuit.constraints.length + "\n");
+        } else {
+            const testerAux = require("circom").testerAux;
+            circuit = await testerAux(pathTmp, path.join(__dirname, "circuits", "upgrade-root.test.circom"));
+        }
+    });
+
+    after( async() => {
+        if (!reuse)
+            fs.unlinkSync(circuitPath);
+    });
+
+    it("should initialize accounts", async () => {
+        for (let i = 0; i < numInitAccounts; i++){
+            const account = new Account(i + 1);
+            account.idx = Constants.firstIdx + i;
+            accounts.push(account);
+        }
+    });
+
+    it("Should check one leaf upgrade", async () => {
+        const db = new SMTMemDB();
+        const rollupDB = await commonjsOld.RollupDB(db);
+
+        const bb = await rollupDB.buildBatch(nTx, nLevels, maxL1Tx, maxFeeTx);
+        await depositTx(bb, accounts[0], 1, 1000);
+
+        await bb.build();
+        await rollupDB.consolidate(bb);
+
+        const upgradeDb = new UpgradeDb(rollupDB, nAccountsUpgrade, nLevels);
+
+        await upgradeDb.doUpgrade();
+
+        await assertUpgradeRoot(upgradeDb, circuit);
+    });
+
+    it("Should check several leaves upgrade in one proof", async () => {
+        const db = new SMTMemDB();
+        const rollupDB = await commonjsOld.RollupDB(db);
+
+        const bb = await rollupDB.buildBatch(nTx, nLevels, maxL1Tx, maxFeeTx);
+        await depositTx(bb, accounts[0], 1, 1000);
+        await depositTx(bb, accounts[1], 2, 500);
+        await depositTx(bb, accounts[2], 3, 250);
+
+        await bb.build();
+        await rollupDB.consolidate(bb);
+
+        const upgradeDb = new UpgradeDb(rollupDB, nAccountsUpgrade, nLevels);
+
+        await upgradeDb.doUpgrade();
+
+        await assertUpgradeRoot(upgradeDb, circuit);
+    });
+
+    it("Should check several leaves upgrade with several proofs", async () => {
+        const db = new SMTMemDB();
+        const rollupDB = await commonjsOld.RollupDB(db);
+
+        // Fill 10 accounts:
+        // - 2 full proofs
+        // - 1 proof: 2 accounts and 2 empty
+        const bb1 = await rollupDB.buildBatch(nTx, nLevels, maxL1Tx, maxFeeTx);
+        for (let i = 0; i < maxL1Tx; i++){
+            await depositTx(bb1, accounts[i], i, i*238);
+        }
+        await bb1.build();
+        await rollupDB.consolidate(bb1);
+
+        const bb2 = await rollupDB.buildBatch(nTx, nLevels, maxL1Tx, maxFeeTx);
+        for (let i = 0; i < maxL1Tx; i++){
+            await depositTx(bb2, accounts[i + maxL1Tx], 10, 20000);
+        }
+        await bb2.build();
+        await rollupDB.consolidate(bb2);
+
+
+        const upgradeDb = new UpgradeDb(rollupDB, nAccountsUpgrade, nLevels);
+
+        await upgradeDb.doUpgrade();
+
+        await assertUpgradeRoot(upgradeDb, circuit);
+    });
+});

--- a/test/upgrade-root/upgrade-step.test.js
+++ b/test/upgrade-root/upgrade-step.test.js
@@ -1,0 +1,120 @@
+const { expect } = require("chai");
+const fs = require("fs");
+const path = require("path");
+const tester = require("circom").tester;
+const Scalar = require("ffjavascript").Scalar;
+const SMTMemDB = require("circomlib").SMTMemDB;
+
+const commonjsOld = require("@hermeznetwork/commonjs-old");
+const RollupDB = require("@hermeznetwork/commonjs").RollupDB;
+const Account = require("@hermeznetwork/commonjs").HermezAccount;
+const Constants = require("@hermeznetwork/commonjs").Constants;
+const txUtils = require("@hermeznetwork/commonjs").txUtils;
+const float40 = require("@hermeznetwork/commonjs").float40;
+
+const { depositTx, printSignals } = require("../helpers/helpers");
+const { assertUpgradeSteps } = require("./helpers-upgrade/helpers-upgrade");
+const UpgradeDb = require("../../js/upgrade-db");
+
+describe("Test upgrade-step", function () {
+    this.timeout(0);
+
+    const reuse = false;
+    const pathTmp = "/tmp/circom_7888jFqbR1qDZW77";
+
+    let circuitPath = path.join(__dirname, "upgrade-step.test.circom");
+    let circuit;
+
+    const nAccountsUpgrade = 2;
+
+    const nTx = 10;
+    const nLevels = 16;
+    const maxL1Tx = 5;
+    const maxFeeTx = 5;
+
+    const numInitAccounts = 100;
+    const accounts = [];
+
+    before( async() => {
+        if (!reuse){
+            const circuitCode = `
+                include "../../src/upgrade-root/upgrade-step.circom";
+                component main = UpgradeStep(${nLevels});
+            `;
+
+            fs.writeFileSync(circuitPath, circuitCode, "utf8");
+
+            circuit = await tester(circuitPath, {reduceConstraints:false});
+            await circuit.loadConstraints();
+            console.log("Constraints: " + circuit.constraints.length + "\n");
+        } else {
+            const testerAux = require("circom").testerAux;
+            circuit = await testerAux(pathTmp, path.join(__dirname, "circuits", "upgrade-step.test.circom"));
+        }
+    });
+
+    after( async() => {
+        if (!reuse)
+            fs.unlinkSync(circuitPath);
+    });
+
+    it("should initialize accounts", async () => {
+        for (let i = 0; i < numInitAccounts; i++){
+            const account = new Account(i + 1);
+            account.idx = Constants.firstIdx + i;
+            accounts.push(account);
+        }
+    });
+
+    it("Should check migration step one leaf", async () => {
+        const db = new SMTMemDB();
+        const rollupDB = await commonjsOld.RollupDB(db);
+
+        const bb = await rollupDB.buildBatch(nTx, nLevels, maxL1Tx, maxFeeTx);
+        await depositTx(bb, accounts[0], 1, 1000);
+
+        await bb.build();
+        await rollupDB.consolidate(bb);
+
+        const upgradeDb = new UpgradeDb(rollupDB, nAccountsUpgrade, nLevels);
+
+        await upgradeDb.doUpgrade();
+        await assertUpgradeSteps(upgradeDb, circuit);
+    });
+
+    it("Should check migration step several leaves in one proof", async () => {
+        const db = new SMTMemDB();
+        const rollupDB = await commonjsOld.RollupDB(db);
+
+        const bb = await rollupDB.buildBatch(nTx, nLevels, maxL1Tx, maxFeeTx);
+        await depositTx(bb, accounts[0], 1, 1000);
+        await depositTx(bb, accounts[1], 1, 1000);
+
+        await bb.build();
+        await rollupDB.consolidate(bb);
+
+        const upgradeDb = new UpgradeDb(rollupDB, nAccountsUpgrade, nLevels);
+
+        await upgradeDb.doUpgrade();
+        await assertUpgradeSteps(upgradeDb, circuit);
+    });
+
+    it("Should check migration step several leaves in several proofs", async () => {
+        const db = new SMTMemDB();
+        const rollupDB = await commonjsOld.RollupDB(db);
+
+        const bb = await rollupDB.buildBatch(nTx, nLevels, maxL1Tx, maxFeeTx);
+        const totalDeposits = 5;
+        for (let i = 0; i < totalDeposits; i++){
+            await depositTx(bb, accounts[i], i, 1000*i);
+        }
+
+        await bb.build();
+        await rollupDB.consolidate(bb);
+
+        const upgradeDb = new UpgradeDb(rollupDB, nAccountsUpgrade, nLevels);
+
+        await upgradeDb.doUpgrade();
+        await assertUpgradeSteps(upgradeDb, circuit);
+    });
+});


### PR DESCRIPTION
This PR does the following:
- implement `upgrade-root.circom` which updated each account of the state-tree with the new account fields, `exitBalance` and `accumulateHash`
- add test `upgrade-root.circom`

Close #46 