### PR TITLE
implement massive-migrations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,9 @@ name: Main CI
 
 on:
   push:
-    branches: [master, feature/upgrade-v1]
+    branches: [master, feature/massive-migrations]
   pull_request:
-    branches: [master, feature/upgrade-v1]
+    branches: [master, feature/massive-migrations]
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "zkSNARK circuit implementing hermez protocol",
   "scripts": {
     "setup": "npm i",
-    "eslint": "npx eslint test/** tools/*.js tools/helpers/*.js",
-    "test": "npx mocha --max-old-space-size=4096 ./test/*.test.js && npx mocha ./test/lib/*.test.js",
+    "eslint": "npx eslint test/** tools/*.js tools/**/*.js",
+    "test": "npx mocha --max-old-space-size=4096 ./test/*.test.js && npx mocha ./test/lib/*.test.js && npm run test:migrations",
+    "test:migrations": "npx mocha --max-old-space-size=4096 ./test/massive-migrations/*.test.js",
     "extend-circom": "node ./tools/reuse-compiled-circuits/reuse-circuits.js"
   },
   "keywords": [

--- a/src/hash-inputs.circom
+++ b/src/hash-inputs.circom
@@ -72,7 +72,7 @@ template HashInputs(nLevels, nTx, maxL1Tx, maxFeeTx) {
     component n2bOldStateRoot = Num2Bits(256);
     n2bOldStateRoot.in <== oldStateRoot;
 
-    // newStateRoott
+    // newStateRoot
     component n2bNewStateRoot = Num2Bits(256);
     n2bNewStateRoot.in <== newStateRoot;
 

--- a/src/massive-migrations/compute-acc-hash.circom
+++ b/src/massive-migrations/compute-acc-hash.circom
@@ -1,0 +1,87 @@
+include "../../node_modules/circomlib/circuits/bitify.circom";
+include "../../node_modules/circomlib/circuits/poseidon.circom";
+include "../../node_modules/circomlib/circuits/comparators.circom";
+include "../../node_modules/circomlib/circuits/mux1.circom";
+
+include "../lib/decode-float.circom";
+
+/**
+ * Decode L1L2 data-availability and compute accumulated hash
+ * @input inAccHash - {Field} - initial accumulated hash
+ * @input L1L2TxsData - {Field} - transaction data-availability
+ * @input inCouner - {Field} - initial transaction counter
+ * @output userFee - {Field} - user fee selector
+ * @output amount - {Field} - amount sent
+ * @output toIdx - {Uint48} - merkle tree index of the receiver leaf
+ * @output fromIdx - {Uint48} - merkle tree index of the sender leaf
+ */
+template ComputeDecodeAccumulateHash(nLevels) {
+    signal input inAccHash;
+    signal input L1L2TxsData;
+    signal input inCounter;
+
+    signal output userFee;     // 8         0..7
+    signal output amount;      // 40        8..47
+    signal output toIdx;       // nLevels   48..48+nLevels-1
+    signal output fromIdx;     // nLevels   48+nLevels..48+2*nLevels-1
+
+    signal output outCounter;
+    signal output outAccHash;
+    signal output isNop;
+
+    var i;
+
+    // decode data
+    component n2bData = Num2Bits(2*nLevels + 40 + 8);
+    n2bData.in <== L1L2TxsData;
+
+    // userFee
+    component b2nUserFee = Bits2Num(8);
+    for (i = 0; i < 8; i++) {
+        b2nUserFee.in[i] <== n2bData.out[i];
+    }
+    b2nUserFee.out ==> userFee;
+
+    // amount
+    component amountF = DecodeFloatBin();
+    for (i = 0; i < 40; i++) {
+        amountF.in[i] <== n2bData.out[8 + i];
+    }
+    amountF.out ==> amount;
+
+    // toIdx
+    component b2nTo = Bits2Num(nLevels);
+    for (i = 0; i < nLevels; i++) {
+        b2nTo.in[i] <== n2bData.out[8 + 40 + i];
+    }
+    b2nTo.out ==> toIdx;
+
+    // fromIdx
+    component b2nFrom = Bits2Num(nLevels);
+    for (i = 0; i < nLevels; i++) {
+        b2nFrom.in[i] <== n2bData.out[8 + 40 + nLevels + i];
+    }
+    b2nFrom.out ==> fromIdx;
+    
+    var IDX_NOP = 0; 
+
+    // comparator
+    component isIdxNop = IsEqual();
+    isIdxNop.in[0] <== IDX_NOP;
+    isIdxNop.in[1] <== toIdx;
+
+    // compute accHash
+    component computeAccumulatedHash = Poseidon(2);
+    computeAccumulatedHash.inputs[0] <== inAccHash;
+    computeAccumulatedHash.inputs[1] <== L1L2TxsData;
+
+    // select input accHash or computed accHash
+    component selectAccHash = Mux1();
+    selectAccHash.c[0] <== computeAccumulatedHash.out;
+    selectAccHash.c[1] <== inAccHash;
+    selectAccHash.s <== isIdxNop.out;
+
+    outAccHash <== selectAccHash.out;
+    outCounter <== inCounter + (1 - isIdxNop.out);
+    isNop <== isIdxNop.out;
+}

--- a/src/massive-migrations/hash-inputs.circom
+++ b/src/massive-migrations/hash-inputs.circom
@@ -1,0 +1,172 @@
+include "../../node_modules/circomlib/circuits/poseidon.circom";
+include "../../node_modules/circomlib/circuits/sha256/sha256.circom";
+include "../../node_modules/circomlib/circuits/bitify.circom";
+
+/**
+ * Compute the sha256 hash of all pretended public inputs
+ * @param nLevels - merkle tree depth
+ * @input initSourceStateRoot - {Field} - initial batch source state root
+ * @input finalSourceStateRoot - {Field} - final batch source state root
+ * @input destinyOldStateRoot - {Field} - old state root
+ * @input destinyNewStateRoot - {Field} - new state root
+ * @input oldLastIdx - {Uint48}	- old last merkle tree index created
+ * @input newLastIdx - {Uint48} - new last merkle tree index created
+ * @input migrationIdx - {Uint48} - migration merkle tree index on source rollup
+ * @input feeIdx - {Uint48} - merkle tree index to receive fees
+ * @input batchesToMigrate - {Uint32} - number of batches that will be migrated
+ * @output hashInputsOut - {Field} - sha256 hash of pretended public inputs
+ */
+template HashInputs(nLevels) {
+    // bits for each public input type
+    var bitsIndexMax = 48; // MAX_NLEVELS
+    var bitsIndex = nLevels;
+    var bitsRoots = 256;
+    var bitsBatch = 32;
+
+    // inputs
+    signal input initSourceStateRoot;
+    signal input finalSourceStateRoot;
+    signal input destinyOldStateRoot;
+    signal input destinyNewStateRoot;
+    signal input oldLastIdx;
+    signal input newLastIdx;
+    signal input migrationIdx;
+    signal input feeIdx;
+    signal input batchesToMigrate;
+
+    // output
+    signal output hashInputsOut;
+
+    var i;
+
+    // get bits from all inputs
+    ////////
+    // initSourceStateRoot
+    component n2bInitSourceStateRoot = Num2Bits(bitsRoots);
+    n2bInitSourceStateRoot.in <== initSourceStateRoot;
+
+    // finalSourceStateRoot
+    component n2bFinalSourceStateRoot = Num2Bits(bitsRoots);
+    n2bFinalSourceStateRoot.in <== finalSourceStateRoot;
+
+    // destinyOldStateRoot
+    component n2bDestinyOldStateRoot = Num2Bits(bitsRoots);
+    n2bDestinyOldStateRoot.in <== destinyOldStateRoot;
+
+    // destinyNewStateRoot
+    component n2bDestinyNewStateRoot = Num2Bits(bitsRoots);
+    n2bDestinyNewStateRoot.in <== destinyNewStateRoot;
+
+    // oldLastIdx
+    component n2bOldLastIdx = Num2Bits(bitsIndexMax);
+    n2bOldLastIdx.in <== oldLastIdx;
+
+    var paddingOldLastIdx = 0;
+    for (i = bitsIndex; i < bitsIndexMax; i++) {
+        paddingOldLastIdx += n2bOldLastIdx.out[i];
+    }
+    paddingOldLastIdx === 0;
+
+    // newLastIdx
+    component n2bNewLastIdx = Num2Bits(bitsIndexMax);
+    n2bNewLastIdx.in <== newLastIdx;
+
+    var paddingNewLastIdx = 0;
+    for (i = bitsIndex; i < bitsIndexMax; i++) {
+        paddingNewLastIdx += n2bNewLastIdx.out[i];
+    }
+    paddingNewLastIdx === 0;
+
+    // migrationIdx
+    component n2bMigrationIdx = Num2Bits(bitsIndexMax);
+    n2bMigrationIdx.in <== migrationIdx;
+
+    var paddingMigrationIdx = 0;
+    for (i = bitsIndex; i < bitsIndexMax; i++) {
+        paddingMigrationIdx += n2bMigrationIdx.out[i];
+    }
+    paddingMigrationIdx === 0;
+
+    // feeIdx
+    component n2bFeeIdx = Num2Bits(bitsIndexMax);
+    n2bFeeIdx.in <== feeIdx;
+
+    var paddingFeeIdx = 0;
+    for (i = bitsIndex; i < bitsIndexMax; i++) {
+        paddingFeeIdx += n2bFeeIdx.out[i];
+    }
+    paddingFeeIdx === 0;
+
+    // batchesToMigrate
+    component n2bBatchesToMigrate = Num2Bits(bitsBatch);
+    n2bBatchesToMigrate.in <== batchesToMigrate;
+
+    // build SHA256 with all inputs
+    ////////
+    var totalBitsSha256 = 4*bitsRoots + 4*bitsIndexMax + bitsBatch;
+
+    component inputsHasher = Sha256(totalBitsSha256);
+
+    var offset = 0;
+
+    // add initSourceStateRoot
+    for (i = 0; i < bitsRoots; i++) {
+        inputsHasher.in[offset + bitsRoots - 1 - i] <== n2bInitSourceStateRoot.out[i];
+    }
+    offset = offset + bitsRoots;
+
+    // add finalSourceStateRoot
+    for (i = 0; i < bitsRoots; i++) {
+        inputsHasher.in[offset + bitsRoots - 1 - i] <== n2bFinalSourceStateRoot.out[i];
+    }
+    offset = offset + bitsRoots;
+
+    // add destinyOldStateRoot
+    for (i = 0; i < bitsRoots; i++) {
+        inputsHasher.in[offset + bitsRoots - 1 - i] <== n2bDestinyOldStateRoot.out[i];
+    }
+    offset = offset + bitsRoots;
+
+    // add destinyNewStateRoot
+    for (i = 0; i < bitsRoots; i++) {
+        inputsHasher.in[offset + bitsRoots - 1 - i] <== n2bDestinyNewStateRoot.out[i];
+    }
+    offset = offset + bitsRoots;
+
+    // add oldLastIdx
+    for (i = 0; i < bitsIndexMax; i++) {
+        inputsHasher.in[offset + bitsIndexMax - 1 - i] <== n2bOldLastIdx.out[i];
+    }
+    offset = offset + bitsIndexMax;
+
+    // add newLastIdx
+    for (i = 0; i < bitsIndexMax; i++) {
+        inputsHasher.in[offset + bitsIndexMax - 1 - i] <== n2bNewLastIdx.out[i];
+    }
+    offset = offset + bitsIndexMax;
+
+    // add migrationIdx
+    for (i = 0; i < bitsIndexMax; i++) {
+        inputsHasher.in[offset + bitsIndexMax - 1 - i] <== n2bMigrationIdx.out[i];
+    }
+    offset = offset + bitsIndexMax;
+
+    // add feeIdx
+    for (i = 0; i < bitsIndexMax; i++) {
+        inputsHasher.in[offset + bitsIndexMax - 1 - i] <== n2bFeeIdx.out[i];
+    }
+    offset = offset + bitsIndexMax;
+
+    // add batchesToMigrate
+    for (i = 0; i < bitsBatch; i++) {
+        inputsHasher.in[offset + bitsBatch - 1 - i] <== n2bBatchesToMigrate.out[i];
+    }
+
+    // get hash output
+    component n2bHashInputsOut = Bits2Num(256);
+    for (i = 0; i < 256; i++) {
+        n2bHashInputsOut.in[i] <== inputsHasher.out[255-i];
+    }
+
+    hashInputsOut <== n2bHashInputsOut.out;
+}

--- a/src/massive-migrations/migrate-main.circom
+++ b/src/massive-migrations/migrate-main.circom
@@ -1,0 +1,386 @@
+include "../../node_modules/circomlib/circuits/smt/smtverifier.circom";
+include "../../node_modules/circomlib/circuits/bitify.circom";
+include "../../node_modules/circomlib/circuits/comparators.circom";
+
+include "../fee-tx.circom";
+include "../lib/hash-state.circom";
+include "./compute-acc-hash.circom";
+include "./migrate-tx.circom";
+include "./hash-inputs.circom";
+
+/**
+ * Decodes and process all rollup transactions and pay accumulated fees
+ * @param nTx - absolute maximum of L1 or L2 transactions
+ * @param nLevels - merkle tree depth
+ * @input imOutAccHash[nTx-1] - {Array(Field)} - intermediary signals: decode transaction computed accumulated hash
+ * @input imOutCounter[nTx-1] - {Array(Field)} - intermediary signals: decode transaction counter
+ * @input imStateRoot[nTx-1] - {Array(Field)} - intermediary signals: transaction final state root
+ * @input imOutIdx[nTx-1] - {Array(Uint48)} - intermediary signals: transaction final index merkle tree assigned
+ * @input imAccFeeOut[nTx-1] - {Array(Uin192)} - intermediary signals: transaction final accumulate fee 
+ * @input imInitStateRootFeeTx - {Field} - intermediary signals: state root before processing fee transaction
+ * @input imFinalAccFee - {Uin192} - intermediary signals: accumulated fee before processing fee transaction
+ * @input imFinalOutIdx - {Uint48} - intermediary signals: final index merkle tre assigned
+ * @input initSourceStateRoot - {Field} - initial state root source rollup
+ * @input finalSourceStateRoot - {Field} - final state root source rollup
+ * @input oldStateRoot - {Field} - initial state root
+ * @input oldLastIdx - {Uint48} - old last index assigned
+ * @input migrationIdx - {Uint48} - migration merkle tree index on source rollup
+ * @input feeIdx - {Uint48} - merkle tree index to receive fees
+ * @input totalBatchesToMigrate - {Uint32} - number of batches that will be migrated
+ * @input tokenID - {Uint32} - tokenID of the migration leaf
+ * @input initBalance - {Uint192} - balance of the migration leaf on the initial state root
+ * @input finalBalance - {Uint192} - balance of the migration leaf on the final state root
+ * @input ethAddr - {Uint160} - ethAddr of the migration leaf
+ * @input initExitBalance - {Uint192} - exit balance of the migration leaf on the initial source state root
+ * @input finalExitBalance - {Uint192} - exit balance of the migration leaf on the final source state root
+ * @input initAccHash - {Field} - received transactions hash chain of the migration leaf on the initial state root
+ * @input finalAccHash - {Field} - received transactions hash chain of the migration leaf on the final state root
+ * @input initSiblings[nLevels + 1] - {Array[Field)]} - siblings merkle proof of the migration leaf on the initial state root
+ * @input finalSiblings[nLevels + 1] - {Array[Field)]} - siblings merkle proof of the migration leaf on the final state root
+ * @input L1-L2 data availability[nTx] - {Array[Field]} - data-availability of all transactions to migrate
+ * @input tokenID1[nTx] - {Array(Uint32)} - tokenID of the source rollup leaf 
+ * @input nonce1[nTx] - {Array(Uint40)} - nonce of the source rollup leaf
+ * @input sign1[nTx] - {Array(Bool)} - sign of the source rollup leaf
+ * @input balance1[nTx] - {Array(Uint192)} - balance of the source rollup leaf
+ * @input ay1[nTx] - {Array(Field)} - ay of the source rollup leaf
+ * @input ethAddr1[nTx] - {Array(Uint160)} - ethAddr of the source rollup leaf
+ * @input exitBalance1[nTx] - {Array(Uint192)} - account exit balance of the source rollup leaf
+ * @input accumulatedHash1[nTx] - {Array(Field)} - received transactions hash chain of the source rollup leaf
+ * @input siblings1[nTx][nLevels + 1] - {Array[Array(Field)]} - siblings merkle proof of the source rollup leaf
+ * @input idxDestiny[nTx] - {Array[Uint48]} - merkle tree index to receiver balance migrated
+ * @input nonce2[nTx] - {Array(Uint40)} - nonce of the receiver leaf
+ * @input balance2[nTx] - {Array(Uint192)} - balance of the receiver leaf
+ * @input exitBalance2[nTx] - {Array(Uint192)} - exit balance of the receiver leaf
+ * @input accumulatedHash2[nTx] - {Array(Field)} - received transactions hash chain of the receiver leaf
+ * @input siblings2[nTx][nLevels + 1] - {Array[Array(Field)]} - siblings merkle proof of the receiver leaf
+ * @input isOld0_2[nTx] - {Array(Bool)} - flag to require old key - value
+ * @input oldKey2[nTx] - {Array(Uint48)} - old key of the receiver leaf
+ * @input oldValue2[nTx] - {Array(Field)} - old value of the receiver leaf
+ * @input tokenID3 - {Uint32} - tokenID of the fee receiver leaf
+ * @input nonce3 - {Uint40} - nonce of the fee receiver leaf
+ * @input sign3 - {Bool} - sign of the fee receiver leaf
+ * @input balance3 - {Uint192} - balance of the fee receiver leaf
+ * @input ay3 - {Field} - ay of the fee receiver leaf
+ * @input ethAddr3 - {Uint160} - ethAddr of the fee receiver leaf
+ * @input exitBalance3 - {Uint192} - account exit balance of the fee receiver leaf
+ * @input accumulatedHash3 - {Field} - received transactions hash chain of the fee receiver leaf
+ * @input siblings3[nLevels + 1] - {Array(Field)} - siblings merkle proof of the fee receiver leaf
+ * @output hashGlobalInputs - {Field} - hash of all pretended input signals
+ */
+template MigrateMain(nTx, nLevels) {
+    // Phases migrate-main circuit:
+        // A: Verify correctness of accumulated hash for migration idx in initSourceStateRoot and finalSourceStateRoot
+        // B: Decode and verify transactions to process
+        // C: Check minimum batches to process or minimum transaction to process
+        // D: Verify correctness data provided for each transaction idx
+        // E: Process migrate transactions in oldStateRoot
+        // F: Process accumulated fee tx
+        // G: Hash global inputs
+
+    // Unique public signal
+    signal output hashGlobalInputs;
+
+    // Intermediary States to parallelize witness computation
+    // decode-compute-accumulated-hash
+    signal private input imOutAccHash[nTx-1];
+    signal private input imOutCounter[nTx-1];
+    // migration-tx
+    signal private input imStateRoot[nTx-1];
+    signal private input imOutIdx[nTx-1];
+    signal private input imAccFeeOut[nTx-1];
+    // fee-tx
+    signal private input imInitStateRootFeeTx;
+    signal private input imFinalAccFee;
+    // hash global input
+    signal private input imFinalOutIdx;
+
+    // private signals taking part of the hashGlobalInputs
+    signal private input initSourceStateRoot;
+    signal private input finalSourceStateRoot;
+    signal private input oldStateRoot;
+    signal private input oldLastIdx;
+    signal private input migrationIdx;
+    signal private input feeIdx;
+    signal private input totalBatchesToMigrate;
+
+    // signals needed to proof accumulatedHash in initSourceStateRoot & finalSourceStateRoot
+    signal private input tokenID;
+    signal private input initBalance;
+    signal private input finalBalance;
+    signal private input ethAddr;
+    signal private input initExitBalance;
+    signal private input finalExitBalance;
+    signal private input initAccHash;
+    signal private input finalAccHash;
+    signal private input initSiblings[nLevels+1];
+    signal private input finalSiblings[nLevels+1];
+
+    // data availability for each transaction to process
+    signal private input L1L2TxsData[nTx];
+
+    // signals to proof fromIdx[nTx] data correctness
+    signal private input tokenID1[nTx];
+    signal private input nonce1[nTx];
+    signal private input sign1[nTx];
+    signal private input balance1[nTx];
+    signal private input ay1[nTx];
+    signal private input ethAddr1[nTx];
+    signal private input exitBalance1[nTx];
+    signal private input accumulatedHash1[nTx];
+    signal private input siblings1[nTx][nLevels+1];
+
+    // signals needed to process migration transactions
+    // signaling add balance to the same leaf or create new one
+    signal private input idxDestiny[nTx];
+    // receiver state
+    signal private input nonce2[nTx];
+    signal private input balance2[nTx];
+    signal private input exitBalance2[nTx];
+    signal private input accumulatedHash2[nTx];
+    signal private input siblings2[nTx][nLevels+1];
+    // Required for inserts and deletes
+    signal private input isOld0_2[nTx];
+    signal private input oldKey2[nTx];
+    signal private input oldValue2[nTx];
+
+    // signals needed to process fee tx
+    signal private input tokenID3;
+    signal private input nonce3;
+    signal private input sign3;
+    signal private input balance3;
+    signal private input ay3;
+    signal private input ethAddr3;
+    signal private input exitBalance3;
+    signal private input accumulatedHash3;
+    signal private input siblings3[nLevels+1];
+
+    var i;
+    var j;
+
+    // A: verify correctness of accumulated hash for migration idx in initSourceStateRoot and finalSourceStateRoot
+    //////////
+    var SIGN_EXIT_ONLY = 1;
+    var AY_EXIT_ONLY = (1<<253) - 1; // 0x1FFF...FFFF
+
+    // build init state and verify it
+    component initState = HashState();
+    initState.tokenID <== tokenID;
+    initState.nonce <== 0; // only-exit accounts cannot perform L2 tx
+    initState.sign <== SIGN_EXIT_ONLY;
+    initState.balance <== initBalance;
+    initState.ay <== AY_EXIT_ONLY;
+    initState.ethAddr <== ethAddr;
+    initState.exitBalance <== initExitBalance;
+    initState.accumulatedHash <== initAccHash;
+
+	component initSmtVerify = SMTVerifier(nLevels + 1);
+	initSmtVerify.enabled <== 1;
+	initSmtVerify.fnc <== 0;
+	initSmtVerify.root <== initSourceStateRoot;
+	for (var i = 0; i < nLevels + 1; i++) {
+		initSmtVerify.siblings[i] <== initSiblings[i];
+	}
+	initSmtVerify.oldKey <== 0;
+	initSmtVerify.oldValue <== 0;
+	initSmtVerify.isOld0 <== 0;
+	initSmtVerify.key <== migrationIdx;
+	initSmtVerify.value <== initState.out;
+
+    // build final state and verify it
+    component finalState = HashState();
+    finalState.tokenID <== tokenID;
+    finalState.nonce <== 0;
+    finalState.sign <== SIGN_EXIT_ONLY;
+    finalState.balance <== finalBalance;
+    finalState.ay <== AY_EXIT_ONLY;
+    finalState.ethAddr <== ethAddr;
+    finalState.exitBalance <== finalExitBalance;
+    finalState.accumulatedHash <== finalAccHash;
+
+    component finalSmtVerify = SMTVerifier(nLevels + 1);
+	finalSmtVerify.enabled <== 1;
+	finalSmtVerify.fnc <== 0;
+	finalSmtVerify.root <== finalSourceStateRoot;
+	for (var i = 0; i < nLevels + 1; i++) {
+		finalSmtVerify.siblings[i] <== finalSiblings[i];
+	}
+	finalSmtVerify.oldKey <== 0;
+	finalSmtVerify.oldValue <== 0;
+	finalSmtVerify.isOld0 <== 0;
+	finalSmtVerify.key <== migrationIdx;
+	finalSmtVerify.value <== finalState.out;
+
+    // B: Decode and verify transactions to process
+    //////////
+    // decode and verify data availability
+    component decodeTx[nTx];
+
+    for (i = 0; i < nTx; i++){
+        decodeTx[i] = ComputeDecodeAccumulateHash(nLevels);
+
+        if (i == 0) {
+            decodeTx[i].inAccHash <== initAccHash;
+            decodeTx[i].inCounter <== 0;
+        } else {
+            decodeTx[i].inAccHash <== imOutAccHash[i-1];
+            decodeTx[i].inCounter <== imOutCounter[i-1];
+        }
+        decodeTx[i].L1L2TxsData <== L1L2TxsData[i];
+    }
+
+    // check integrity decode-compute intermediary signals
+    ////////
+    for (i = 0; i < nTx-1; i++) {
+        decodeTx[i].outAccHash  === imOutAccHash[i];
+        decodeTx[i].outCounter  === imOutCounter[i];
+    }
+
+    // check integrity final accumulated hash 
+    decodeTx[nTx-1].outAccHash === finalAccHash;
+
+    // C: Check minimum batches to process or minimum transaction to process
+    //////////
+    // If there are more than or equal MIN_BATCHES_MIGRATE to migrate, do not check MIN_TXS_MIGRATE
+    // If there are less than MIN_BATCHES_MIGRATE to migrate, then check MIN_TXS_MIGRATE
+
+    // checks: MIN_BATCHES_MIGRATE > totalBatchesToMigrate
+    var MIN_BATCHES_MIGRATE = 10;
+    component minBatchesToMigrate = GreaterThan(8);
+
+    minBatchesToMigrate.in[0] <== MIN_BATCHES_MIGRATE;
+    minBatchesToMigrate.in[1] <== totalBatchesToMigrate;
+
+    // checks: numTxToProcess > MIN_TXS_MIGRATE
+    var MIN_TXS_MIGRATE = 100;
+    component minTxToMigrate = GreaterThan(8);
+
+    minTxToMigrate.in[0] <== decodeTx[nTx-1].outCounter;
+    minTxToMigrate.in[1] <== MIN_TXS_MIGRATE;
+
+    (1 - minTxToMigrate.out) * minBatchesToMigrate.out === 0;
+
+    // D: Verify correctness data provided for each transaction idx
+    //////////
+    component smtVerify[nTx];
+    component stateFromIdx[nTx];
+
+    for (i = 0; i < nTx; i++){
+        smtVerify[i] = SMTVerifier(nLevels + 1);
+        stateFromIdx[i] = HashState();
+
+        stateFromIdx[i].tokenID <== tokenID1[i];
+        stateFromIdx[i].nonce <== nonce1[i];
+        stateFromIdx[i].sign <== sign1[i];
+        stateFromIdx[i].balance <== balance1[i];
+        stateFromIdx[i].ay <== ay1[i];
+        stateFromIdx[i].ethAddr <== ethAddr1[i];
+        stateFromIdx[i].exitBalance <== exitBalance1[i];
+        stateFromIdx[i].accumulatedHash <== accumulatedHash1[i];
+
+        smtVerify[i].enabled <== (1 - decodeTx[i].isNop);
+	    smtVerify[i].fnc <== 0;
+	    smtVerify[i].root <== finalSourceStateRoot;
+	    for (j = 0; j < nLevels + 1; j++) {
+	    	smtVerify[i].siblings[j] <== siblings1[i][j];
+	    }
+	    smtVerify[i].oldKey <== 0;
+	    smtVerify[i].oldValue <== 0;
+	    smtVerify[i].isOld0 <== 0;
+	    smtVerify[i].key <== decodeTx[i].fromIdx;
+	    smtVerify[i].value <== stateFromIdx[i].out;
+    }
+
+    // E: Process migrate transactions in oldStateRoot
+    //////////
+    component migrateTx[nTx];
+
+    for (i = 0; i < nTx; i++){
+        migrateTx[i] = MigrateTx(nLevels);
+
+        if (i == 0) {
+            migrateTx[i].oldStateRoot <== oldStateRoot;
+            migrateTx[i].inIdx <== oldLastIdx;
+            migrateTx[i].accFeeIn <== 0;
+        } else {
+            migrateTx[i].oldStateRoot <== imStateRoot[i-1];
+            migrateTx[i].inIdx <== imOutIdx[i-1];
+            migrateTx[i].accFeeIn <== imAccFeeOut[i-1];
+        }
+
+        migrateTx[i].isNop <== decodeTx[i].isNop;
+        migrateTx[i].idx <== idxDestiny[i];
+        migrateTx[i].migrateAmount <== decodeTx[i].amount;
+        migrateTx[i].userFee <== decodeTx[i].userFee;
+        migrateTx[i].ay <== ay1[i];
+        migrateTx[i].sign <== sign1[i];
+        migrateTx[i].ethAddr <== ethAddr1[i];
+        migrateTx[i].tokenID <== tokenID1[i];
+
+        migrateTx[i].isOld0 <== isOld0_2[i];
+        migrateTx[i].oldKey <== oldKey2[i];
+        migrateTx[i].oldValue <== oldValue2[i];
+
+        migrateTx[i].nonce <== nonce2[i];
+        migrateTx[i].balance <== balance2[i];
+        migrateTx[i].exitBalance <== exitBalance2[i];
+        migrateTx[i].accumulatedHash <== accumulatedHash2[i];
+
+        for (j = 0; j < nLevels + 1; j++) {
+	    	migrateTx[i].siblings[j] <== siblings2[i][j];
+	    }
+    }
+
+    // check integrity transactions intermediary signals
+    for (i = 0; i < nTx-1; i++) {
+        migrateTx[i].newStateRoot  === imStateRoot[i];
+        migrateTx[i].accFeeOut  === imAccFeeOut[i];
+        migrateTx[i].outIdx  === imOutIdx[i];
+    }
+
+    // F: Process accumulated fee tx
+    ////////
+    component feeTx;
+    feeTx = FeeTx(nLevels);
+
+    feeTx.oldStateRoot <== migrateTx[nTx-1].newStateRoot;
+    feeTx.feePlanToken <== tokenID;
+    feeTx.feeIdx <== feeIdx;
+    feeTx.accFee <== imFinalAccFee;
+
+    feeTx.tokenID <== tokenID3;
+    feeTx.nonce <== nonce3;
+    feeTx.sign <== sign3;
+    feeTx.balance <== balance3;
+    feeTx.ay <== ay3;
+    feeTx.ethAddr <== ethAddr3;
+    feeTx.exitBalance <== exitBalance3;
+    feeTx.accumulatedHash <== accumulatedHash3;
+
+    for (j = 0; j < nLevels+1; j++) {
+        feeTx.siblings[j] <== siblings3[j]
+    }
+
+    // check integrity transactions intermediary signals
+    migrateTx[nTx-1].newStateRoot === imInitStateRootFeeTx;
+    migrateTx[nTx-1].accFeeOut === imFinalAccFee;
+
+    // G: Hash global inputs
+    ////////
+    component hasherInputs = HashInputs(nLevels);
+
+    hasherInputs.initSourceStateRoot <== initSourceStateRoot;
+    hasherInputs.finalSourceStateRoot <== finalSourceStateRoot;
+    hasherInputs.destinyOldStateRoot <== oldStateRoot;
+    hasherInputs.destinyNewStateRoot <== feeTx.newStateRoot;
+    hasherInputs.oldLastIdx <== oldLastIdx;
+    hasherInputs.newLastIdx <== imFinalOutIdx;
+    hasherInputs.migrationIdx <== migrationIdx;
+    hasherInputs.feeIdx <== feeIdx;
+    hasherInputs.batchesToMigrate <== totalBatchesToMigrate;
+
+    // check integrity hash global inputs intermediary signals
+    migrateTx[nTx-1].outIdx === imFinalOutIdx;
+
+    // set public output
+    hashGlobalInputs <== hasherInputs.hashInputsOut;
+}

--- a/src/massive-migrations/migrate-tx-states.circom
+++ b/src/massive-migrations/migrate-tx-states.circom
@@ -1,0 +1,68 @@
+include "../../node_modules/circomlib/circuits/comparators.circom";
+include "../../node_modules/circomlib/circuits/bitify.circom";
+include "../../node_modules/circomlib/circuits/mux1.circom";
+
+include "../compute-fee.circom";
+
+/**
+ * Compute migration transaction states
+ * @input idx - {Uint48} - merkle tree index to receive migration amount
+ * @input inIdx - {Uint48} - old last merkle tree index assigned
+ * @input userFee - {Uint16} - user fee selector
+ * @input migrationAmount - {Uint192} - amount to migrate
+ * @output fee2Charge - {Uint192} - effective transaction fee
+ * @output depositAmount - {Uint192} - effective deposit amount
+ * @output isInsert - {Bool} - determines smt processor functionality
+ * @output outIdx - {Uint48} - new last merkle tree index assigned
+ */
+template MigrationTxStates(){
+    signal input idx;
+    signal input inIdx;
+    signal input userFee;
+    signal input migrateAmount;
+    signal input isNop;
+
+    signal output fee2Charge;
+    signal output depositAmount;
+    signal output isInsert;
+    signal output outIdx;
+
+    // select SMT processor functionality
+    component idxIsZero = IsZero();
+    idxIsZero.in <== idx;
+
+    isInsert <== idxIsZero.out;
+
+    // compute fee
+    ////////
+    component computeFee = ComputeFee();
+    computeFee.feeSel <== userFee;
+    computeFee.amount <== migrateAmount;
+    computeFee.applyFee <== 1;
+
+    // check enough balance to pay fees
+    signal underflowOk;
+
+    component n2bSender = Num2Bits(193);
+    n2bSender.in <== (1<<192) + migrateAmount - computeFee.feeOut;
+    underflowOk <== n2bSender.out[192];
+
+    // select fee to accumulate
+    component selectFee = Mux1();
+    selectFee.c[0] <== migrateAmount;
+    selectFee.c[1] <== computeFee.feeOut;
+    selectFee.s <== underflowOk;
+
+    fee2Charge <== selectFee.out*(1 - isNop);
+
+    // select final deposit
+    component selectDepositAmount = Mux1();
+    selectDepositAmount.c[0] <== 0;
+    selectDepositAmount.c[1] <== migrateAmount - computeFee.feeOut;
+    selectDepositAmount.s <== underflowOk;
+
+    depositAmount <== selectDepositAmount.out;
+
+    // increment Idx if it is an insert
+    outIdx <== inIdx + isInsert*(1 - isNop);
+}

--- a/src/massive-migrations/migrate-tx.circom
+++ b/src/massive-migrations/migrate-tx.circom
@@ -1,0 +1,175 @@
+include "../../node_modules/circomlib/circuits/smt/smtprocessor.circom";
+include "../../node_modules/circomlib/circuits/mux1.circom";
+
+include "../lib/hash-state.circom"
+include "./migrate-tx-states.circom"
+
+/**
+ * Process migration transaction
+ * @input oldStateRoot - {Field} - old state root
+ * @input accFeeIn - {Field} - initial accumulated fee
+ * @input inIdx - {Uint48} - old last merkle tree index assigned
+ * @input idx - {Uint48} - merkle tree index to receive migration balance
+ * @input migrationAmount - {Uint192} - amount to migrate and insert into the state tree
+ * @input userFee - {Uint16} - user fee selector
+ * @input ay - {Field} - ay of the receiver leaf
+ * @input sign - {Bool} - sign of the receiver leaf
+ * @input ethAddr - {Uint160} - ethAddr of the receiver leaf
+ * @input tokenID - {Uint32} - tokenID of the receiver leaf
+ * @input isOld0 - {Bool} - flag to require old key - value
+ * @input oldKey - {Uint48} - old key of the receiver leaf
+ * @input oldValue - {Field} - old value of the receiver leaf
+ * @input nonce - {Uint40} - nonce of the sender leaf
+ * @input balance - {Uint192} - balance of the sender leaf
+ * @input exitBalance - {Uint192} - account exit balance
+ * @input accumulatedHash - {Field} - received transactions hash chain
+ * @input siblings[nLevels + 1] - {Array(Field)} - siblings merkle proof of the sender leaf
+ * @output newStateRoot - {Field} - new state root
+ * @output accFeeOut - {Field} - final accumulated fee
+ * @output outIdx - {Uint48} - new last merkle tree index assigned
+ */
+template MigrateTx(nLevels) {
+    // Phases rollup-main circuit:
+      // A: Compute migration transaction states
+      // B: Build old and new states
+      // C: Processor new state tree
+      // D: assign outputs
+
+    signal input oldStateRoot;
+    signal input accFeeIn;
+    signal input inIdx;
+    signal input isNop;
+
+    // 0 means INSERT, any other value means UPDATE
+    signal input idx;
+    // state vars
+    signal input migrateAmount;
+    signal input userFee;
+    signal input ay;
+    signal input sign;
+    signal input ethAddr;
+    signal input tokenID;
+    signal input isOld0;
+    signal input oldKey;
+    signal input oldValue;
+
+    // aux signals to compute hash states
+    signal input nonce;
+    signal input balance;
+    signal input exitBalance;
+    signal input accumulatedHash;
+    signal input siblings[nLevels+1];
+
+    signal output newStateRoot;
+    signal output accFeeOut;
+    signal output outIdx;
+
+	var i;
+
+    // A: Compute migration transaction states
+    component txStates = MigrationTxStates();
+    txStates.userFee <== userFee;
+    txStates.migrateAmount <== migrateAmount;
+    txStates.idx <== idx;
+    txStates.inIdx <== inIdx;
+    txStates.isNop <== isNop;
+
+    // B: Build old and new states
+    
+    // oldState Packer
+    component oldStHash = HashState();
+    oldStHash.tokenID <== tokenID; // same as source rollup
+    oldStHash.nonce <== nonce;
+    oldStHash.sign <== sign; // same as source rollup
+    oldStHash.balance <== balance;
+    oldStHash.ay <== ay; // same as source rollup
+    oldStHash.ethAddr <== ethAddr; // same as source rollup
+    oldStHash.exitBalance <== exitBalance;
+    oldStHash.accumulatedHash <== accumulatedHash;
+
+    // processor old key would be taken from:
+      // UPDATE: 'idx' to update, chosen by the coordinator
+      // INSERT: 'oldKey' which is set by the coordinator
+    component selectedOldKey = Mux1();
+    selectedOldKey.c[0] <== idx;
+    selectedOldKey.c[1] <== oldKey;
+    selectedOldKey.s <== txStates.isInsert;
+
+    // processor new key would be taken from:
+      // UPDATE: 'idx' to update, chosen by the coordinator
+      // INSERT: 'outIdx' computed by migration-states
+    component selectedNewKey = Mux1();
+    selectedNewKey.c[0] <== idx;
+    selectedNewKey.c[1] <== txStates.outIdx;
+    selectedNewKey.s <== txStates.isInsert;
+
+    // processor state hash would be taken from:
+      // UPDATE: state hash is selected from oldState Packer
+      // INSERT: 'oldValue' which is set by the coordinator
+    component selectedOldValue = Mux1();
+    selectedOldValue.c[0] <== oldStHash.out;
+    selectedOldValue.c[1] <== oldValue;
+    selectedOldValue.s <== txStates.isInsert;    
+    
+    // new state hash: nonce
+      // UPDATE: old nonce
+      // INSERT: 0
+    component selectedNonce = Mux1();
+    selectedNonce.c[0] <== nonce;
+    selectedNonce.c[1] <== 0;
+    selectedNonce.s <== txStates.isInsert;
+
+    // new state hash: balance
+      // UPDATE: depositAmount + balance
+      // INSERT: depositAmount
+    component selectedBalance = Mux1();
+    selectedBalance.c[0] <== txStates.depositAmount + balance;
+    selectedBalance.c[1] <== txStates.depositAmount;
+    selectedBalance.s <== txStates.isInsert;
+
+    // new state hash: exitBalance
+      // UPDATE: old exitBlance
+      // INSERT: 0
+    component selectedExitBalance = Mux1();
+    selectedExitBalance.c[0] <== exitBalance;
+    selectedExitBalance.c[1] <== 0;
+    selectedExitBalance.s <== txStates.isInsert;
+
+    // new state hash: accumulatedHash
+      // UPDATE: old accumulatedHash
+      // INSERT: 0
+    component selectedAccHash = Mux1();
+    selectedAccHash.c[0] <== accumulatedHash;
+    selectedAccHash.c[1] <== 0;
+    selectedAccHash.s <== txStates.isInsert;
+
+    // newState1 hash state
+    component newStHash = HashState();
+    newStHash.tokenID <== tokenID;
+    newStHash.nonce <== selectedNonce.out;
+    newStHash.sign <== sign;
+    newStHash.balance <== selectedBalance.out;
+    newStHash.ay <== ay;
+    newStHash.ethAddr <== ethAddr;
+    newStHash.exitBalance <== selectedExitBalance.out;
+    newStHash.accumulatedHash <== selectedAccHash.out;
+
+    // C: Processor new state tree
+    component processor = SMTProcessor(nLevels+1);
+    processor.oldRoot <== oldStateRoot;
+    for (i = 0; i < nLevels + 1; i++) {
+        processor.siblings[i] <== siblings[i];
+    }
+    processor.oldKey <== selectedOldKey.out;
+    processor.oldValue <== selectedOldValue.out;
+    processor.isOld0 <== isOld0;
+    processor.newKey <== selectedNewKey.out;
+    processor.newValue <== newStHash.out;
+    processor.fnc[0] <== txStates.isInsert*(1 - isNop);
+    processor.fnc[1] <== (1 - txStates.isInsert)*(1 - isNop);
+
+    // D: assign outputs
+    accFeeOut <== accFeeIn + txStates.fee2Charge;
+    newStateRoot <== processor.newRoot;
+    outIdx <== txStates.outIdx;
+}

--- a/src/rollup-main.circom
+++ b/src/rollup-main.circom
@@ -54,8 +54,8 @@ include "./fee-tx.circom";
  * @input balance1[nTx] - {Array(Uint192)} - balance of the sender leaf
  * @input ay1[nTx] - {Array(Field)} - ay of the sender leaf
  * @input ethAddr1[nTx] - {Array(Uint160)} - ethAddr of the sender leaf
- * @input exitBalance1[nTx] - {Array(Uint192)} - account exit balance
- * @input accumulatedHash1[nTx] - {Array(Field)} - received transactions hash chain
+ * @input exitBalance1[nTx] - {Array(Uint192)} - exit balance of the sender leaf
+ * @input accumulatedHash1[nTx] - {Array(Field)} - received transactions hash chain of the sender leaf
  * @input siblings1[nTx][nLevels + 1] - {Array[Array(Field)]} - siblings merkle proof of the sender leaf
  * @input isOld0_1[nTx] - {Array(Bool)} - flag to require old key - value
  * @input oldKey1[nTx] - {Array(Uint48)} - old key of the sender leaf
@@ -66,8 +66,8 @@ include "./fee-tx.circom";
  * @input balance2[nTx] - {Array(Uint192)} - balance of the receiver leaf
  * @input ay2[nTx] - {Array(Field)} - ay of the receiver leaf
  * @input ethAddr2[nTx] - {Array(Uint160)} - ethAddr of the receiver leaf
- * @input exitBalance2[nTx] - {Array(Uint192)} - account exit balance
- * @input accumulatedHash2[nTx] - {Array(Field)} - received transactions hash chain
+ * @input exitBalance2[nTx] - {Array(Uint192)} - exit balance of the receiver leaf
+ * @input accumulatedHash2[nTx] - {Array(Field)} - received transactions hash chain of the receiver leaf
  * @input siblings2[nTx][nLevels + 1] - {Array[Array(Field)]} - siblings merkle proof of the receiver leaf
  * @input tokenID3[maxFeeTx] - {Array(Uint32)} - tokenID of leafs feeIdxs
  * @input nonce3[maxFeeTx] - {Array(Uint40)} - nonce of leafs feeIdxs
@@ -75,8 +75,8 @@ include "./fee-tx.circom";
  * @input balance3[maxFeeTx] - {Array(Uint192)} - balance of leafs feeIdxs
  * @input ay3[maxFeeTx] - {Array(Field)} - ay of leafs feeIdxs
  * @input ethAddr3[maxFeeTx] - {Array(Uint160)} - ethAddr of leafs feeIdxs
- * @input exitBalance3[nTx] - {Array(Uint192)} - account exit balance
- * @input accumulatedHash3[nTx] - {Array(Field)} - received transactions hash chain
+ * @input exitBalance3[maxFeeTx] - {Array(Uint192)} - exit balance of leafs feeIdxs
+ * @input accumulatedHash3[maxFeeTx] - {Array(Field)} - received transactions hash chain of leafs feeIdxs
  * @input siblings3[maxFeeTx][nLevels + 1] - {Array[Array(Field)}} - siblings merkle proof of leafs Idxs
  * @output hashGlobalInputs - {Field} - hash of all pretended input signals
  */
@@ -352,7 +352,7 @@ template RollupMain(nTx, nLevels, maxL1Tx, maxFeeTx){
         rollupTx[i].exitBalance1 <== exitBalance1[i];
         rollupTx[i].accumulatedHash1 <== accumulatedHash1[i];
         for (j = 0; j < nLevels+1; j++) {
-            rollupTx[i].siblings1[j] <== siblings1[i][j]
+            rollupTx[i].siblings1[j] <== siblings1[i][j];
         }
         rollupTx[i].isOld0_1 <== isOld0_1[i];
         rollupTx[i].oldKey1 <== oldKey1[i];

--- a/test/massive-migrations/compute-acc-hash.test.js
+++ b/test/massive-migrations/compute-acc-hash.test.js
@@ -1,0 +1,150 @@
+const fs = require("fs");
+const path = require("path");
+const tester = require("circom").tester;
+const SMTMemDB = require("circomlib").SMTMemDB;
+const Scalar = require("ffjavascript").Scalar;
+
+const RollupDB = require("@hermeznetwork/commonjs").RollupDB;
+const Account = require("@hermeznetwork/commonjs").HermezAccount;
+const txUtils = require("@hermeznetwork/commonjs").txUtils;
+const helpers = require("../helpers/helpers");
+
+describe("Test ComputeDecodeAccumulateHash", function () {
+    this.timeout(0);
+    let circuitPath = path.join(__dirname, "compute-acc-hash.test.circom");
+    let circuit;
+
+    const nLevels = 16;
+    const maxTx = 4;
+    const maxL1Tx = 2;
+
+    before( async() => {
+        const circuitCode = `
+            include "../../src/massive-migrations/compute-acc-hash.circom";
+            component main = ComputeDecodeAccumulateHash(${nLevels});
+        `;
+        fs.writeFileSync(circuitPath, circuitCode, "utf8");
+
+        circuit = await tester(circuitPath, {reduceConstraints:false});
+        await circuit.loadConstraints();
+        console.log("Constraints: " + circuit.constraints.length + "\n");
+    });
+
+    after( async() => {
+        fs.unlinkSync(circuitPath);
+    });
+
+    it("Should decode L1L2Data and compute accumulate hash", async () => {
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(maxTx, nLevels, maxL1Tx);
+
+        const account1 = new Account(1);
+        const account2 = new Account(2);
+
+        helpers.depositTx(bb, account1, 1, 1000);
+        helpers.depositOnlyExitTx(bb, account2, 1, 2000);
+
+        await bb.build();
+        await rollupDB.consolidate(bb);
+
+        const oldState = await rollupDB.getStateByIdx(257);
+
+        const bb2 = await rollupDB.buildBatch(maxTx, nLevels, maxL1Tx);
+
+        const tx = {
+            fromIdx: 256,
+            toIdx: 257,
+            tokenID: 1,
+            amount: Scalar.e(50),
+            nonce: 0,
+            userFee: 126,
+        };
+
+        account1.signTx(tx);
+        bb2.addTx(tx);
+
+        await bb2.build();
+        await rollupDB.consolidate(bb2);
+
+        const newState = await rollupDB.getStateByIdx(257);
+
+        const L2L1Data = await rollupDB.getL1L2Data(bb2.batchNumber);
+
+        const input = {
+            inAccHash: oldState.accumulatedHash,
+            L1L2TxsData: Scalar.fromString(L2L1Data[0], 16),
+            inCounter: 20,
+        };
+
+        const decodeDataL1L2 = txUtils.decodeL2Tx(L2L1Data[0], nLevels);
+
+        const output = {
+            userFee: decodeDataL1L2.userFee,
+            amount: decodeDataL1L2.amount,
+            toIdx: decodeDataL1L2.toIdx,
+            fromIdx: decodeDataL1L2.fromIdx,
+            outCounter: input.inCounter + 1,
+            outAccHash: newState.accumulatedHash,
+            isNop: 0,
+        };
+
+        const w = await circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        await circuit.assertOut(w, output);
+    });
+
+    it("Should compute NOP L1L2Data", async () => {
+        // Start a new state
+        const db = new SMTMemDB();
+        const rollupDB = await RollupDB(db);
+        const bb = await rollupDB.buildBatch(maxTx, nLevels, maxL1Tx);
+
+        const account1 = new Account(1);
+        const account2 = new Account(2);
+
+        helpers.depositTx(bb, account1, 1, 1000);
+        helpers.depositOnlyExitTx(bb, account2, 1, 2000);
+
+        await bb.build();
+        await rollupDB.consolidate(bb);
+
+        const oldState = await rollupDB.getStateByIdx(257);
+
+        const bb2 = await rollupDB.buildBatch(maxTx, nLevels, maxL1Tx);
+
+        const tx = {
+            fromIdx: 256,
+            toIdx: 257,
+            tokenID: 1,
+            amount: Scalar.e(50),
+            nonce: 0,
+            userFee: 126,
+        };
+
+        account1.signTx(tx);
+        bb2.addTx(tx);
+
+        await bb2.build();
+        await rollupDB.consolidate(bb2);
+
+        const input = {
+            inAccHash: oldState.accumulatedHash,
+            L1L2TxsData: Scalar.e(0),
+            inCounter: 20,
+        };
+
+        const output = {
+            userFee: Scalar.e(0),
+            amount: Scalar.e(0),
+            toIdx: Scalar.e(0),
+            fromIdx: Scalar.e(0),
+            outCounter: input.inCounter,
+            outAccHash: input.inAccHash,
+            isNop: 1,
+        };
+
+        const w = await circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        await circuit.assertOut(w, output);
+    });
+});

--- a/test/massive-migrations/hash-inputs.test.js
+++ b/test/massive-migrations/hash-inputs.test.js
@@ -1,0 +1,175 @@
+const fs = require("fs");
+const path = require("path");
+const tester = require("circom").tester;
+const Scalar = require("ffjavascript").Scalar;
+const SMTMemDB = require("circomlib").SMTMemDB;
+
+const RollupDB = require("@hermeznetwork/commonjs").RollupDB;
+const Account = require("@hermeznetwork/commonjs").HermezAccount;
+const helpersMigrations = require("./helpers-migrations/helpers-migrations");
+
+describe("Test HashInputs", function () {
+    this.timeout(0);
+
+    const reuse = false;
+    const pathTmp = "/tmp/circom_14421rpwfmG0Bw8oh";
+
+    let circuitPath = path.join(__dirname, "hash-inputs.test.circom");
+    let circuit;
+
+    const maxTx = 20;
+    const maxL1Tx = 5;
+    const nLevels = 16;
+    const numAccounts = 5;
+    const migrationAccount = numAccounts - 1;
+    const numDeposits = migrationAccount - 1;
+    const maxMigrationTx = 10;
+
+    let accounts = [];
+    let sourceRollupDb;
+    let destRollupDb;
+
+    before( async() => {
+        if (!reuse){
+            const circuitCode = `
+                include "../../src/massive-migrations/hash-inputs.circom";
+                component main = HashInputs(${nLevels});
+            `;
+            fs.writeFileSync(circuitPath, circuitCode, "utf8");
+
+            circuit = await tester(circuitPath, {reduceConstraints:false});
+            await circuit.loadConstraints();
+            console.log("Constraints: " + circuit.constraints.length + "\n");
+        } else {
+            const testerAux = require("circom").testerAux;
+            circuit = await testerAux(pathTmp, path.join(__dirname, "circuits", "hash-inputs.test.circom"));
+        }
+    });
+
+    after( async() => {
+        if (!reuse)
+            fs.unlinkSync(circuitPath);
+    });
+
+    it("Should initialize test environment", async () => {
+        for (let i = 0; i < numAccounts; i++){
+            const account = new Account(i+1);
+            accounts.push(account);
+        }
+
+        sourceRollupDb = await helpersMigrations.initSourceRollupDb(maxTx, nLevels, maxL1Tx, accounts, numDeposits, migrationAccount);
+
+        // RollupDestinyDB
+        const destDb = new SMTMemDB();
+        destRollupDb = await RollupDB(destDb);
+        await destRollupDb.setMigrationIdx(accounts[migrationAccount].migrationIdx);
+    });
+
+    it("Should check empty migration txs", async () => {
+        // add empty batches to migrate minBatches
+        const bbToBuild = 10;
+
+        while (sourceRollupDb.lastBatch < bbToBuild){
+            const bb = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+            bb.build();
+            await sourceRollupDb.consolidate(bb);
+        }
+
+        // migration-builder
+        const initBatch = 1;
+        const finalBatch = 10;
+        const mb = await destRollupDb.buildMigration(maxMigrationTx, nLevels, sourceRollupDb, initBatch, finalBatch);
+
+        await mb.build();
+
+        const pretendedInputs = mb.getPretendedPublicInputs();
+
+        const inputs = {
+            initSourceStateRoot: pretendedInputs.initSourceStateRoot,
+            finalSourceStateRoot: pretendedInputs.finalSourceStateRoot,
+            destinyOldStateRoot: pretendedInputs.oldStateRoot,
+            destinyNewStateRoot: pretendedInputs.newStateRoot,
+            oldLastIdx: pretendedInputs.oldLastIdx,
+            newLastIdx: pretendedInputs.newLastIdx,
+            migrationIdx: pretendedInputs.migrationIdx,
+            feeIdx: pretendedInputs.feeIdx,
+            batchesToMigrate: pretendedInputs.batchesToMigrate,
+        };
+
+        const w = await circuit.calculateWitness(inputs, {logTrigger:false, logOutput: false, logSet: false});
+
+        const checkOut = {
+            hashInputsOut: mb.getHashInputs(),
+        };
+
+        await circuit.assertOut(w, checkOut);
+    });
+
+    it("Should check several migration txs", async () => {
+        const bb2 = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+        // two sends to exit-only account
+        const tx = {
+            fromIdx: accounts[0].sourceIdx,
+            toIdx: destRollupDb.migrationIdx,
+            tokenID: 1,
+            amount: Scalar.e(20),
+            nonce: 0,
+            userFee: 125,
+        };
+
+        const tx2 = {
+            fromIdx: accounts[1].sourceIdx,
+            toIdx: destRollupDb.migrationIdx,
+            tokenID: 1,
+            amount: Scalar.e(100),
+            nonce: 0,
+            userFee: 127,
+        };
+
+        accounts[0].signTx(tx);
+        accounts[1].signTx(tx2);
+        bb2.addTx(tx);
+        bb2.addTx(tx2);
+
+        await bb2.build();
+        await sourceRollupDb.consolidate(bb2);
+
+        // add empty batches to migrate minBatches
+        const bbToBuild = 20;
+
+        while (sourceRollupDb.lastBatch < bbToBuild){
+            const bb = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+            bb.build();
+            await sourceRollupDb.consolidate(bb);
+        }
+
+        // migration-builder
+        const initBatch = 11;
+        const finalBatch = 20;
+        const mb = await destRollupDb.buildMigration(maxMigrationTx, nLevels, sourceRollupDb, initBatch, finalBatch);
+
+        await mb.build();
+
+        const pretendedInputs = mb.getPretendedPublicInputs();
+
+        const inputs = {
+            initSourceStateRoot: pretendedInputs.initSourceStateRoot,
+            finalSourceStateRoot: pretendedInputs.finalSourceStateRoot,
+            destinyOldStateRoot: pretendedInputs.oldStateRoot,
+            destinyNewStateRoot: pretendedInputs.newStateRoot,
+            oldLastIdx: pretendedInputs.oldLastIdx,
+            newLastIdx: pretendedInputs.newLastIdx,
+            migrationIdx: pretendedInputs.migrationIdx,
+            feeIdx: pretendedInputs.feeIdx,
+            batchesToMigrate: pretendedInputs.batchesToMigrate,
+        };
+
+        const w = await circuit.calculateWitness(inputs, {logTrigger:false, logOutput: false, logSet: false});
+
+        const checkOut = {
+            hashInputsOut: mb.getHashInputs(),
+        };
+
+        await circuit.assertOut(w, checkOut);
+    });
+});

--- a/test/massive-migrations/helpers-migrations/helpers-migrations.js
+++ b/test/massive-migrations/helpers-migrations/helpers-migrations.js
@@ -1,0 +1,114 @@
+const SMTMemDB = require("circomlib").SMTMemDB;
+const Scalar = require("ffjavascript").Scalar;
+const RollupDB = require("@hermeznetwork/commonjs").RollupDB;
+const Constants = require("@hermeznetwork/commonjs").Constants;
+const txUtils = require("@hermeznetwork/commonjs").txUtils;
+
+const helpers = require("../../helpers/helpers");
+
+async function setAccountIdx(account, idx){
+    account.idx = idx;
+}
+
+async function initSourceRollupDb(maxTx, nLevels, maxL1Tx, accounts, numDeposits, migrationAccount){
+    // RollupSourceDB
+    const db = new SMTMemDB();
+    const rollupSourceDB = await RollupDB(db);
+    const bb = await rollupSourceDB.buildBatch(maxTx, nLevels, maxL1Tx);
+
+    for (let i = 0; i < numDeposits; i++){
+        helpers.depositTx(bb, accounts[i], 1, 1000);
+        accounts[i].sourceIdx = (i == 0) ? Constants.firstIdx + 1: accounts[i-1].sourceIdx + 1;
+    }
+
+    // add migrationIdx
+    helpers.depositOnlyExitTx(bb, accounts[migrationAccount], 1, 0);
+    accounts[migrationAccount].migrationIdx = accounts[numDeposits - 1].sourceIdx + 1;
+
+    await bb.build();
+    await rollupSourceDB.consolidate(bb);
+
+    return rollupSourceDB;
+}
+
+async function printStateAccounts(accounts, rollupDb){
+    for (let i = 0; i < accounts.length; i++){
+        if (accounts[i].sourceIdx != undefined){
+            const state = await rollupDb.getStateByIdx(accounts[i].sourceIdx);
+            console.log(`State ${accounts[i].sourceIdx}: `, state);
+        }
+    }
+}
+
+async function getSingleMigrationTxInput(mb, numTx){
+    const nLevels = mb.nLevels;
+    const finalInput = mb.getInput();
+    const finalOutput = mb.getPretendedPublicInputs();
+
+    const L1L2DataHex = txUtils.scalarToHexL2Data(finalInput.L1L2TxsData[numTx], nLevels);
+    const L1L2TxData = txUtils.decodeL2Tx(L1L2DataHex, nLevels);
+
+    const input = {
+        // global
+        oldStateRoot: finalInput.imStateRoot[numTx-1] || finalInput.oldStateRoot,
+        accFeeIn: finalInput.imAccFeeOut[numTx-1] || Scalar.e(0),
+        inIdx: finalInput.imOutIdx[numTx-1] || mb.initialIdx,
+        isNop: Scalar.eq(L1L2TxData.toIdx, 0) ? Scalar.e(1): Scalar.e(0),
+        // 0 means INSERT, any other value means UPDATE
+        idx: finalInput.idxDestiny[numTx],
+        // state vars
+        migrateAmount: L1L2TxData.amount,
+        userFee: L1L2TxData.userFee,
+        ay: finalInput.ay1[numTx],
+        sign: finalInput.sign1[numTx],
+        ethAddr: finalInput.ethAddr1[numTx],
+        tokenID: finalInput.tokenID1[numTx],
+        // insert and deletes
+        isOld0: finalInput.isOld0_2[numTx],
+        oldKey: finalInput.oldKey2[numTx],
+        oldValue: finalInput.oldValue2[numTx],
+        // aux signals to compute hash states
+        nonce: finalInput.nonce2[numTx],
+        balance: finalInput.balance2[numTx],
+        exitBalance: finalInput.exitBalance2[numTx],
+        accumulatedHash: finalInput.accumulatedHash2[numTx],
+        siblings: finalInput.siblings2[numTx],
+    };
+
+    const output = {
+        newStateRoot: finalInput.imStateRoot[numTx] || finalOutput.newStateRoot,
+        accFeeOut: finalInput.imAccFeeOut[numTx] || mb.accumulatedFee,
+        outIdx: finalInput.imOutIdx[numTx] || finalOutput.newLastIdx,
+    };
+
+    return {input, output};
+}
+
+async function assertTxs(mb, circuit){
+    for (let i = 0; i < mb.maxMigrationTx; i++){
+        let res = await getSingleMigrationTxInput(mb, i);
+
+        let w = await circuit.calculateWitness(res.input, {logTrigger:false, logOutput: false, logSet: false});
+        await circuit.assertOut(w, res.output);
+    }
+}
+
+async function assertMigrationBatch(mb, circuit){
+    const input = mb.getInput();
+    const w = await circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+
+    const output = {
+        hashGlobalInputs: mb.getHashInputs(),
+    };
+
+    await circuit.assertOut(w, output);
+}
+
+module.exports = {
+    setAccountIdx,
+    initSourceRollupDb,
+    printStateAccounts,
+    assertTxs,
+    getSingleMigrationTxInput,
+    assertMigrationBatch
+};

--- a/test/massive-migrations/migrate-main.test.js
+++ b/test/massive-migrations/migrate-main.test.js
@@ -1,0 +1,233 @@
+const fs = require("fs");
+const path = require("path");
+const tester = require("circom").tester;
+const Scalar = require("ffjavascript").Scalar;
+const SMTMemDB = require("circomlib").SMTMemDB;
+
+const RollupDB = require("@hermeznetwork/commonjs").RollupDB;
+const Account = require("@hermeznetwork/commonjs").HermezAccount;
+const helpersMigrations = require("./helpers-migrations/helpers-migrations");
+
+describe("Test MigrateMain", function () {
+    this.timeout(0);
+
+    const reuse = false;
+    const pathTmp = "/tmp/circom_23869J2BDrmdZb8ye";
+
+    let circuitPath = path.join(__dirname, "migrate-main.test.circom");
+    let circuit;
+
+    const maxTx = 20;
+    const maxL1Tx = 5;
+    const nLevels = 16;
+    const numAccounts = 5;
+    const migrationAccount = numAccounts - 1;
+    const numDeposits = migrationAccount - 1;
+    const maxMigrationTx = 2;
+
+    let accounts = [];
+    let sourceRollupDb;
+    let destRollupDb;
+
+    before( async() => {
+        if (!reuse){
+            const circuitCode = `
+                include "../../src/massive-migrations/migrate-main.circom";
+                component main = MigrateMain(${maxMigrationTx}, ${nLevels});
+            `;
+
+            fs.writeFileSync(circuitPath, circuitCode, "utf8");
+
+            circuit = await tester(circuitPath, {reduceConstraints:false});
+            await circuit.loadConstraints();
+            console.log("Constraints: " + circuit.constraints.length + "\n");
+        } else {
+            const testerAux = require("circom").testerAux;
+            circuit = await testerAux(pathTmp, path.join(__dirname, "circuits", "migrate-main.test.circom"));
+        }
+    });
+
+    after( async() => {
+        if (!reuse)
+            fs.unlinkSync(circuitPath);
+    });
+
+    it("Should initialize test environment", async () => {
+        for (let i = 0; i < numAccounts; i++){
+            const account = new Account(i+1);
+            accounts.push(account);
+        }
+
+        sourceRollupDb = await helpersMigrations.initSourceRollupDb(maxTx, nLevels, maxL1Tx, accounts, numDeposits, migrationAccount);
+
+        // RollupDestinyDB
+        const destDb = new SMTMemDB();
+        destRollupDb = await RollupDB(destDb);
+        await destRollupDb.setMigrationIdx(accounts[migrationAccount].migrationIdx);
+    });
+
+    it("Should test empty migration transactions", async () => {
+        // add empty batches to migrate minBatches
+        const bbToBuild = 10;
+
+        while (sourceRollupDb.lastBatch < bbToBuild){
+            const bb = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+            bb.build();
+            await sourceRollupDb.consolidate(bb);
+        }
+
+        // migration-builder
+        const initBatch = 1;
+        const finalBatch = 10;
+        const mb = await destRollupDb.buildMigration(maxMigrationTx, nLevels, sourceRollupDb, initBatch, finalBatch);
+
+        await mb.build();
+        await destRollupDb.consolidateMigrate(mb);
+        await helpersMigrations.assertMigrationBatch(mb, circuit);
+    });
+
+    it("Should check an insert and update migration tx", async () => {
+        const bb2 = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+
+        // transfer to migrateIdx that triggers a migration transaction:
+        // insert
+        const tx = {
+            fromIdx: accounts[0].sourceIdx,
+            toIdx: destRollupDb.migrationIdx,
+            tokenID: 1,
+            amount: Scalar.e(20),
+            nonce: 0,
+            userFee: 125,
+        };
+
+        // transfer to migrateIdx that triggers a migration transaction:
+        // update (leaf already exist)
+        const tx2 = {
+            fromIdx: accounts[0].sourceIdx,
+            toIdx: destRollupDb.migrationIdx,
+            tokenID: 1,
+            amount: Scalar.e(20),
+            nonce: 1,
+            userFee: 125,
+        };
+
+        accounts[0].signTx(tx);
+        accounts[0].signTx(tx2);
+        bb2.addTx(tx);
+        bb2.addTx(tx2);
+
+        await bb2.build();
+        await sourceRollupDb.consolidate(bb2);
+
+        // add empty batches to migrate at least `minBatchesToMigrate`
+        const bbToBuild = 20;
+
+        while (sourceRollupDb.lastBatch < bbToBuild){
+            const bb = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+            bb.build();
+            await sourceRollupDb.consolidate(bb);
+        }
+
+        // migration-builder
+        const initBatch = 10;
+        const finalBatch = 20;
+        const mb = await destRollupDb.buildMigration(maxMigrationTx, nLevels, sourceRollupDb, initBatch, finalBatch);
+
+        await mb.build();
+        await destRollupDb.consolidateMigrate(mb);
+        await helpersMigrations.assertMigrationBatch(mb, circuit);
+    });
+
+    it("Should check several migration txs", async () => {
+        const bb3 = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+
+        // transfer to migrateIdx that triggers a migration transaction:
+        // update (cannot pay fees twice)
+        const tx = {
+            fromIdx: accounts[0].sourceIdx,
+            toIdx: destRollupDb.migrationIdx,
+            tokenID: 1,
+            amount: Scalar.e(100),
+            nonce: 2,
+            userFee: 193,
+        };
+
+        // transfer to migrateIdx that triggers a migration transaction:
+        // insert with 0 amount
+        const tx2 = {
+            fromIdx: accounts[1].sourceIdx,
+            toIdx: destRollupDb.migrationIdx,
+            tokenID: 1,
+            amount: Scalar.e(0),
+            nonce: 0,
+            userFee: 0,
+        };
+
+        accounts[0].signTx(tx);
+        accounts[1].signTx(tx2);
+        bb3.addTx(tx);
+        bb3.addTx(tx2);
+
+        await bb3.build();
+        await sourceRollupDb.consolidate(bb3);
+
+        // add empty batches to migrate at least `minBatchesToMigrate`
+        const bbToBuild = 30;
+
+        while (sourceRollupDb.lastBatch < bbToBuild){
+            const bb = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+            bb.build();
+            await sourceRollupDb.consolidate(bb);
+        }
+
+        // migration-builder
+        const initBatch = 20;
+        const finalBatch = 30;
+        const mb = await destRollupDb.buildMigration(maxMigrationTx, nLevels, sourceRollupDb, initBatch, finalBatch);
+
+        await mb.build();
+        await destRollupDb.consolidateMigrate(mb);
+        await helpersMigrations.assertMigrationBatch(mb, circuit);
+    });
+
+    it("Should check fee transaction", async () => {
+        const bb4 = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+
+        // transfer to migrateIdx that triggers a migration transaction:
+        // update
+        const tx = {
+            fromIdx: accounts[1].sourceIdx,
+            toIdx: destRollupDb.migrationIdx,
+            tokenID: 1,
+            amount: Scalar.e(0),
+            nonce: 1,
+            userFee: 0,
+        };
+
+        accounts[0].signTx(tx);
+        bb4.addTx(tx);
+
+        await bb4.build();
+        await sourceRollupDb.consolidate(bb4);
+
+        // add empty batches to migrate at least `minBatchesToMigrate`
+        const bbToBuild = 40;
+
+        while (sourceRollupDb.lastBatch < bbToBuild){
+            const bb = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+            bb.build();
+            await sourceRollupDb.consolidate(bb);
+        }
+
+        // migration-builder
+        const initBatch = 30;
+        const finalBatch = 40;
+        const mb = await destRollupDb.buildMigration(maxMigrationTx, nLevels, sourceRollupDb, initBatch, finalBatch);
+        // get fees on first account
+        mb.setFeeIdx(256);
+
+        await mb.build();
+        await destRollupDb.consolidateMigrate(mb);
+        await helpersMigrations.assertMigrationBatch(mb, circuit);
+    });
+});

--- a/test/massive-migrations/migrate-tx-states.test.js
+++ b/test/massive-migrations/migrate-tx-states.test.js
@@ -1,0 +1,147 @@
+const fs = require("fs");
+const path = require("path");
+const tester = require("circom").tester;
+const feeUtils = require("@hermeznetwork/commonjs").feeTable;
+const Scalar = require("ffjavascript").Scalar;
+
+describe("Test MigrationTxStates", function () {
+    this.timeout(0);
+    let circuitPath = path.join(__dirname, "migrate-tx-states.test.circom");
+    let circuit;
+
+    before( async() => {
+        const circuitCode = `
+            include "../../src/massive-migrations/migrate-tx-states.circom";
+            component main = MigrationTxStates();
+        `;
+        fs.writeFileSync(circuitPath, circuitCode, "utf8");
+
+        circuit = await tester(circuitPath, {reduceConstraints:false});
+        await circuit.loadConstraints();
+        console.log("Constraints: " + circuit.constraints.length + "\n");
+    });
+
+    after( async() => {
+        fs.unlinkSync(circuitPath);
+    });
+
+    it("Should check UPDATE migrate tx", async () => {
+        const input = {
+            idx: 256,
+            inIdx: 257,
+            userFee: 126,
+            migrateAmount: 100,
+            isNop: 0
+        };
+        const fee = feeUtils.computeFee(input.migrateAmount, input.userFee);
+
+        const w = await circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        const output = {
+            fee2Charge: fee,
+            depositAmount: Scalar.sub(input.migrateAmount, fee),
+            isInsert: 0,
+            outIdx: input.inIdx
+        };
+
+        await circuit.assertOut(w, output);
+    });
+
+    it("Should check INSERT migrate tx", async () => {
+        const input = {
+            idx: 0,
+            inIdx: 257,
+            userFee: 126,
+            migrateAmount: 100,
+            isNop: 0
+        };
+        const fee = feeUtils.computeFee(input.migrateAmount, input.userFee);
+
+        const w = await circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        const output = {
+            fee2Charge: fee,
+            depositAmount: Scalar.sub(input.migrateAmount, fee),
+            isInsert: 1,
+            outIdx: input.inIdx + 1
+        };
+
+        await circuit.assertOut(w, output);
+    });
+
+    it("Should check UPDATE migrate tx underflow", async () => {
+        const input = {
+            idx: 258,
+            inIdx: 258,
+            userFee: 200,
+            migrateAmount: 100,
+            isNop: 0
+        };
+
+        const w = await circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        const output = {
+            fee2Charge: input.migrateAmount,
+            depositAmount: 0,
+            isInsert: 0,
+            outIdx: input.inIdx
+        };
+
+        await circuit.assertOut(w, output);
+    });
+
+    it("Should check INSERT migrate tx underflow", async () => {
+        const input = {
+            idx: 0,
+            inIdx: 1024,
+            userFee: 200,
+            migrateAmount: 100,
+            isNop: 0
+        };
+
+        const w = await circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        const output = {
+            fee2Charge: input.migrateAmount,
+            depositAmount: 0,
+            isInsert: 1,
+            outIdx: input.inIdx + 1
+        };
+
+        await circuit.assertOut(w, output);
+    });
+
+    it("Should check NOP migrate tx", async () => {
+        const input = {
+            idx: 0,
+            inIdx: 1024,
+            userFee: 200,
+            migrateAmount: 100,
+            isNop: 1
+        };
+
+        const w = await circuit.calculateWitness(input, {logTrigger:false, logOutput: false, logSet: false});
+        const output = {
+            fee2Charge: 0,
+            depositAmount: 0,
+            isInsert: 1,
+            outIdx: input.inIdx
+        };
+
+        await circuit.assertOut(w, output);
+
+        const input2 = {
+            idx: 327,
+            inIdx: 1024,
+            userFee: 200,
+            migrateAmount: 100,
+            isNop: 1
+        };
+
+        const w2 = await circuit.calculateWitness(input2, {logTrigger:false, logOutput: false, logSet: false});
+        const output2 = {
+            fee2Charge: 0,
+            depositAmount: 0,
+            isInsert: 0,
+            outIdx: input.inIdx
+        };
+
+        await circuit.assertOut(w2, output2);
+    });
+});

--- a/test/massive-migrations/migrate-tx.test.js
+++ b/test/massive-migrations/migrate-tx.test.js
@@ -1,0 +1,217 @@
+const fs = require("fs");
+const path = require("path");
+const tester = require("circom").tester;
+const Scalar = require("ffjavascript").Scalar;
+const SMTMemDB = require("circomlib").SMTMemDB;
+
+const RollupDB = require("@hermeznetwork/commonjs").RollupDB;
+const Account = require("@hermeznetwork/commonjs").HermezAccount;
+const helpersMigrations = require("./helpers-migrations/helpers-migrations");
+
+describe("Test MigrateTx", function () {
+    this.timeout(0);
+
+    const reuse = false;
+    const pathTmp = "/tmp/circom_22241kzA2pttkBsZI";
+
+    let circuitPath = path.join(__dirname, "migrate-tx.test.circom");
+    let circuit;
+
+    const maxTx = 20;
+    const maxL1Tx = 5;
+    const nLevels = 16;
+    const numAccounts = 5;
+    const migrationAccount = numAccounts - 1;
+    const numDeposits = migrationAccount - 1;
+    const maxMigrationTx = 2;
+
+    let accounts = [];
+    let sourceRollupDb;
+    let destRollupDb;
+
+    before( async() => {
+        if (!reuse){
+            const circuitCode = `
+            include "../../src/massive-migrations/migrate-tx.circom";
+            component main = MigrateTx(${nLevels});
+        `;
+            fs.writeFileSync(circuitPath, circuitCode, "utf8");
+
+            circuit = await tester(circuitPath, {reduceConstraints:false});
+            await circuit.loadConstraints();
+            console.log("Constraints: " + circuit.constraints.length + "\n");
+        } else {
+            const testerAux = require("circom").testerAux;
+            circuit = await testerAux(pathTmp, path.join(__dirname, "circuits", "migrate-tx.test.circom"));
+        }
+    });
+
+    after( async() => {
+        if (!reuse)
+            fs.unlinkSync(circuitPath);
+    });
+
+    it("Should initialize test environment", async () => {
+        for (let i = 0; i < numAccounts; i++){
+            const account = new Account(i+1);
+            accounts.push(account);
+        }
+
+        sourceRollupDb = await helpersMigrations.initSourceRollupDb(maxTx, nLevels, maxL1Tx, accounts, numDeposits, migrationAccount);
+
+        // RollupDestinyDB
+        const destDb = new SMTMemDB();
+        destRollupDb = await RollupDB(destDb);
+        await destRollupDb.setMigrationIdx(accounts[migrationAccount].migrationIdx);
+    });
+
+    it("Should test empty migration transactions", async () => {
+        // add empty batches to migrate minBatches
+        const bbToBuild = 10;
+
+        while (sourceRollupDb.lastBatch < bbToBuild){
+            const bb = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+            bb.build();
+            await sourceRollupDb.consolidate(bb);
+        }
+
+        // migration-builder
+        const initBatch = 1;
+        const finalBatch = 10;
+        const mb = await destRollupDb.buildMigration(maxMigrationTx, nLevels, sourceRollupDb, initBatch, finalBatch);
+
+        await mb.build();
+        await destRollupDb.consolidateMigrate(mb);
+        await helpersMigrations.assertTxs(mb, circuit);
+    });
+
+    it("Should check an insert migration tx", async () => {
+        const bb2 = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+
+        // transfer to migrateIdx that triggers a migration transaction:
+        // insert
+        const tx = {
+            fromIdx: accounts[0].sourceIdx,
+            toIdx: destRollupDb.migrationIdx,
+            tokenID: 1,
+            amount: Scalar.e(20),
+            nonce: 0,
+            userFee: 125,
+        };
+
+        accounts[0].signTx(tx);
+        bb2.addTx(tx);
+
+        await bb2.build();
+        await sourceRollupDb.consolidate(bb2);
+
+        // add empty batches to migrate at least `minBatchesToMigrate`
+        const bbToBuild = 20;
+
+        while (sourceRollupDb.lastBatch < bbToBuild){
+            const bb = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+            bb.build();
+            await sourceRollupDb.consolidate(bb);
+        }
+
+        // migration-builder
+        const initBatch = 10;
+        const finalBatch = 20;
+        const mb = await destRollupDb.buildMigration(maxMigrationTx, nLevels, sourceRollupDb, initBatch, finalBatch);
+
+        await mb.build();
+        await destRollupDb.consolidateMigrate(mb);
+        await helpersMigrations.assertTxs(mb, circuit);
+    });
+
+    it("Should check an update migration tx", async () => {
+        const bb3 = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+
+        // transfer to migrateIdx that triggers a migration transaction:
+        // update (leaf already exist)
+        const tx = {
+            fromIdx: accounts[0].sourceIdx,
+            toIdx: destRollupDb.migrationIdx,
+            tokenID: 1,
+            amount: Scalar.e(20),
+            nonce: 1,
+            userFee: 125,
+        };
+
+        accounts[0].signTx(tx);
+        bb3.addTx(tx);
+
+        await bb3.build();
+        await sourceRollupDb.consolidate(bb3);
+
+        // add empty batches to migrate at least `minBatchesToMigrate`
+        const bbToBuild = 30;
+
+        while (sourceRollupDb.lastBatch < bbToBuild){
+            const bb = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+            bb.build();
+            await sourceRollupDb.consolidate(bb);
+        }
+
+        // migration-builder
+        const initBatch = 20;
+        const finalBatch = 30;
+        const mb = await destRollupDb.buildMigration(maxMigrationTx, nLevels, sourceRollupDb, initBatch, finalBatch);
+
+        await mb.build();
+        await destRollupDb.consolidateMigrate(mb);
+        await helpersMigrations.assertTxs(mb, circuit);
+    });
+
+    it("Should check several migration txs", async () => {
+        const bb4 = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+
+        // transfer to migrateIdx that triggers a migration transaction:
+        // update (cannot pay fees twice)
+        const tx = {
+            fromIdx: accounts[0].sourceIdx,
+            toIdx: destRollupDb.migrationIdx,
+            tokenID: 1,
+            amount: Scalar.e(100),
+            nonce: 2,
+            userFee: 193,
+        };
+
+        // transfer to migrateIdx that triggers a migration transaction:
+        // insert with 0 amount (cannot pay fees twice)
+        const tx2 = {
+            fromIdx: accounts[1].sourceIdx,
+            toIdx: destRollupDb.migrationIdx,
+            tokenID: 1,
+            amount: Scalar.e(0),
+            nonce: 0,
+            userFee: 0,
+        };
+
+        accounts[0].signTx(tx);
+        accounts[1].signTx(tx2);
+        bb4.addTx(tx);
+        bb4.addTx(tx2);
+
+        await bb4.build();
+        await sourceRollupDb.consolidate(bb4);
+
+        // add empty batches to migrate at least `minBatchesToMigrate`
+        const bbToBuild = 40;
+
+        while (sourceRollupDb.lastBatch < bbToBuild){
+            const bb = await sourceRollupDb.buildBatch(maxTx, nLevels, maxL1Tx);
+            bb.build();
+            await sourceRollupDb.consolidate(bb);
+        }
+
+        // migration-builder
+        const initBatch = 30;
+        const finalBatch = 40;
+        const mb = await destRollupDb.buildMigration(maxMigrationTx, nLevels, sourceRollupDb, initBatch, finalBatch);
+
+        await mb.build();
+        await destRollupDb.consolidateMigrate(mb);
+        await helpersMigrations.assertTxs(mb, circuit);
+    });
+});


### PR DESCRIPTION
## NOTE
This PR in `commonjs` repository: https://github.com/hermeznetwork/commonjs/pull/41,  should be merged first in order to fulfill test accordingly

## PR
This PR implements the following:
- `compute-acc-hash.circom`
  - decode data-availability
  - computes accumulated hash chain
- `hash-inputs.circom`
  - computes input global hash
- `migrate-main.circom`
  - verify correctness of data-availability
  - decode transactions
  - check minimum batches or transactions to process
  - process migration transactions
  - process fee transaction
  - compute hash global inputs
- `migrate-tx-states.circom`to migrate
  - compute amount to migrate & fee to charge
  - selects sparse-merkle-tree processor functionality
  - computes new merkle tree index
- `migrate-tx.circom`
  - compute transaction states
  - build old and new states
  - sparse-merkle-tree processor to compute new root         